### PR TITLE
Remove deferred transaction support

### DIFF
--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -334,12 +334,6 @@ extern "C" {
    void send_context_free_inline(char *serialized_action, size_t size) {
       return intrinsics::get().call<intrinsics::send_context_free_inline>(serialized_action, size);
    }
-   void send_deferred(const uint128_t* sender_id, capi_name payer, const char *serialized_transaction, size_t size, uint32_t replace_existing) {
-      return intrinsics::get().call<intrinsics::send_deferred>(sender_id, payer, serialized_transaction, size, replace_existing);
-   }
-   int cancel_deferred(const uint128_t* sender_id) {
-      return intrinsics::get().call<intrinsics::cancel_deferred>(sender_id);
-   }
    int get_context_free_data( uint32_t index, char* buff, size_t size ) {
       return intrinsics::get().call<intrinsics::get_context_free_data>(index, buff, size);
    }

--- a/libraries/native/native/sysio/intrinsics_def.hpp
+++ b/libraries/native/native/sysio/intrinsics_def.hpp
@@ -157,8 +157,6 @@ intrinsic_macro(tapos_block_num) \
 intrinsic_macro(get_action) \
 intrinsic_macro(send_inline) \
 intrinsic_macro(send_context_free_inline) \
-intrinsic_macro(send_deferred) \
-intrinsic_macro(cancel_deferred) \
 intrinsic_macro(get_context_free_data) \
 intrinsic_macro(get_sender) \
 intrinsic_macro(set_action_return_value) \

--- a/libraries/sysiolib/capi/sysio/transaction.h
+++ b/libraries/sysiolib/capi/sysio/transaction.h
@@ -37,40 +37,6 @@ extern "C" {
  * @{
  */
 
- /**
-  *  Sends a deferred transaction.
-  *
-  *  @param sender_id - ID of sender
-  *  @param payer - Account paying for RAM
-  *  @param serialized_transaction - Pointer of serialized transaction to be deferred
-  *  @param size - Size to reserve
-  *  @param replace_existing - f this is `0` then if the provided sender_id is already in use by an in-flight transaction from this contract, which will be a failing assert. If `1` then transaction will atomically cancel/replace the inflight transaction
-  */
-__attribute__((sysio_wasm_import))
-void send_deferred(const uint128_t* sender_id, capi_name payer, const char *serialized_transaction, size_t size, uint32_t replace_existing);
-
- /**
-  *  Cancels a deferred transaction.
-  *
-  *  @brief Cancels a deferred transaction.
-  *  @param sender_id - The id of the sender
-  *
-  *  @pre The deferred transaction ID exists.
-  *  @pre The deferred transaction ID has not yet been published.
-  *  @post Deferred transaction canceled.
-  *
-  *  @return 1 if transaction was canceled, 0 if transaction was not found
-  *
-  *  Example:
-*
-  *  @code
-  *  id = 0xffffffffffffffff
-  *  cancel_deferred( id );
-  *  @endcode
-  */
-__attribute__((sysio_wasm_import))
-int cancel_deferred(const uint128_t* sender_id);
-
 /**
  * Access a copy of the currently executing transaction.
  *

--- a/libraries/sysiolib/contracts/sysio/transaction.hpp
+++ b/libraries/sysiolib/contracts/sysio/transaction.hpp
@@ -14,12 +14,6 @@ namespace sysio {
    namespace internal_use_do_not_use {
       extern "C" {
          __attribute__((sysio_wasm_import))
-         void send_deferred(const uint128_t&, uint64_t, const char*, size_t, uint32_t);
-
-         __attribute__((sysio_wasm_import))
-         int cancel_deferred(const uint128_t&);
-
-         __attribute__((sysio_wasm_import))
          size_t read_transaction(char*, size_t);
 
          __attribute__((sysio_wasm_import))
@@ -114,19 +108,6 @@ namespace sysio {
        */
       transaction(time_point_sec exp = time_point_sec(current_time_point()) + 60) : transaction_header( exp ) {}
 
-      /**
-       *  Sends this transaction, packs the transaction then sends it as a deferred transaction
-       *
-       *  @details Writes the symbol_code as a string to the provided char buffer
-       *  @param sender_id - ID of sender
-       *  @param payer - Account paying for RAM
-       *  @param replace_existing - Defaults to false, if this is `0`/false then if the provided sender_id is already in use by an in-flight transaction from this contract, which will be a failing assert. If `1` then transaction will atomically cancel/replace the inflight transaction
-       */
-      void send(const uint128_t& sender_id, name payer, bool replace_existing = false) const {
-         auto serialize = pack(*this);
-         internal_use_do_not_use::send_deferred(sender_id, payer.value, serialize.data(), serialize.size(), replace_existing);
-      }
-
       std::vector<action>  context_free_actions;
       std::vector<action>  actions;
       extensions_type      transaction_extensions;
@@ -134,47 +115,6 @@ namespace sysio {
       SYSLIB_SERIALIZE_DERIVED( transaction, transaction_header, (context_free_actions)(actions)(transaction_extensions) )
    };
 
-   /**
-    *  Struct onerror contains and sender id and packed transaction
-    *
-    *  @ingroup transaction
-    */
-   struct onerror {
-      uint128_t          sender_id;
-      std::vector<char> sent_trx;
-
-     /**
-      *  from_current_action unpacks and returns a onerror struct
-      *
-      *  @ingroup transaction
-      */
-      static onerror from_current_action() {
-         return unpack_action_data<onerror>();
-      }
-
-     /**
-      * Unpacks and returns a transaction
-      */
-      transaction unpack_sent_trx() const {
-         return unpack<transaction>(sent_trx);
-      }
-
-      SYSLIB_SERIALIZE( onerror, (sender_id)(sent_trx) )
-   };
-
-   /**
-    *  Send a deferred transaction
-    *
-    *  @ingroup transaction
-    *  @param sender_id - Account name of the sender of this deferred transaction
-    *  @param payer - Account name responsible for paying the RAM for this deferred transaction
-    *  @param serialized_transaction - The packed transaction to be deferred
-    *  @param size - The size of the packed transaction, required for persistence.
-    *  @param replace - If true, will replace an existing transaction.
-    */
-   inline void send_deferred(const uint128_t& sender_id, name payer, const char* serialized_transaction, size_t size, bool replace = false) {
-     internal_use_do_not_use::send_deferred(sender_id, payer.value, serialized_transaction, size, replace);
-   }
    /**
     *  Retrieve the indicated action from the active transaction.
     *
@@ -202,29 +142,6 @@ namespace sysio {
     */
    inline size_t read_transaction(char* ptr, size_t sz) {
       return internal_use_do_not_use::read_transaction( ptr, sz );
-   }
-
-    /**
-     *  Cancels a deferred transaction.
-     *
-     *  @ingroup transaction
-     *  @param sender_id - The id of the sender
-     *
-     *  @pre The deferred transaction ID exists.
-     *  @pre The deferred transaction ID has not yet been published.
-     *  @post Deferred transaction canceled.
-     *
-     *  @return 1 if transaction was canceled, 0 if transaction was not found
-     *
-     *  Example:
-*
-     *  @code
-     *  id = 0xffffffffffffffff
-     *  cancel_deferred( id );
-     *  @endcode
-     */
-   inline int cancel_deferred(const uint128_t& sender_id) {
-      return internal_use_do_not_use::cancel_deferred(sender_id);
    }
 
    /**

--- a/tests/toolchain/compile-fail/host_functions_tests.cpp
+++ b/tests/toolchain/compile-fail/host_functions_tests.cpp
@@ -7,7 +7,6 @@ set_proposed_producers_ex : yes
 set_blockchain_parameters_packed : yes
 set_parameters_packed : yes
 set_privileged  : yes
-send_deferred : yes
 */
 
 #include <sysio/sysio.hpp>
@@ -49,7 +48,6 @@ extern "C" __attribute__((sysio_wasm_import)) int32_t db_idx_long_double_store(u
 extern "C" __attribute__((sysio_wasm_import)) void db_idx_long_double_update(int32_t iterator, capi_name payer, const long double* secondary);
 extern "C" __attribute__((sysio_wasm_import)) void db_idx_long_double_remove(int32_t iterator);
 
-extern "C" __attribute__((sysio_wasm_import)) void send_deferred(const uint128_t&, uint64_t, const char*, size_t, uint32_t);
 extern "C" __attribute__((sysio_wasm_import)) int64_t set_proposed_producers( char*, uint32_t );
 extern "C" __attribute__((sysio_wasm_import)) int64_t set_proposed_producers_ex( uint64_t producer_data_format, char *producer_data, uint32_t producer_data_size );
 extern "C" __attribute__((sysio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
@@ -213,11 +211,6 @@ db_idx_long_double_remove
    ACTION_TYPE
    bool dbidxldbr(){
       db_idx_long_double_remove(0);
-      return true;
-   }
-   ACTION_TYPE
-   bool senddefer(){
-      send_deferred(0, 0, NULL, 0, 0);
       return true;
    }
    ACTION_TYPE

--- a/tests/unit/test_contracts/capi/transaction.c
+++ b/tests/unit/test_contracts/capi/transaction.c
@@ -2,8 +2,6 @@
 #include <stddef.h>
 
 void test_transaction( void ) {
-   send_deferred(NULL, 0, NULL, 0, 0);
-   cancel_deferred(NULL);
    read_transaction(NULL, 0);
    transaction_size();
    tapos_block_num();

--- a/tests/unit/test_contracts/simple_tests.cpp
+++ b/tests/unit/test_contracts/simple_tests.cpp
@@ -49,19 +49,7 @@ class [[sysio::contract]] simple_tests : public contract {
          check(nm == "bucky"_n, "should be bucky");
       }
 
-      [[sysio::action]] 
-      void testd(name nm) {
-         transaction t;
-         action act;
-         act.account = "other"_n;
-         act.name    = "testc"_n;
-         act.authorization = {permission_level{get_self(), "active"_n}};
-         std::vector<char> data = pack(nm);
-         t.actions.push_back(act);
-         t.send(nm.value, get_self());
-      }
-
-      [[sysio::on_notify("sysio.token::transfer")]] 
+      [[sysio::on_notify("sysio.token::transfer")]]
       void on_transfer(name from, name to, asset quant, std::string memo) {
          check(get_first_receiver() == "sysio.token"_n, "should be sysio.token");
          print_f("On notify : % % % %", from, to, quant, memo);

--- a/tools/include/sysio/gen.hpp
+++ b/tools/include/sysio/gen.hpp
@@ -893,20 +893,11 @@ struct generation_utils {
          "db_idx_long_double_store",
          "db_idx_long_double_update",
          "db_idx_long_double_remove",
-         "send_deferred",
          "send_inline",
          "send_context_free_inline"
       };
 
       return write_host_funcs.count(func_decl->getNameInfo().getAsString()) >= 1;
-   }
-
-   inline bool is_deferred_transaction_func( const std::string& t ) {
-      static const std::set<std::string> deferred_transaction_funcs =
-      {
-         "send_deferred",
-      };
-      return deferred_transaction_funcs.count(t) >= 1;
    }
 
    inline bool is_inline_action_func( const std::string& t ) {


### PR DESCRIPTION
## Change Description

Remove `send_deferred` and `cancel_deferred` support.
Wire.Network will not support deferred transactions from genesis.

## API Changes
- [ x ] API Changes

Remove `send_deferred` and `cancel_deferred` host (also called intrinsics) functions.

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
