### PR TITLE
Optimize KV table abstractions, add kv::global

### DIFF
--- a/docs/kv-global.md
+++ b/docs/kv-global.md
@@ -1,0 +1,94 @@
+# sysio::kv::global
+
+## Include
+
+```cpp
+#include <sysio/kv_global.hpp>
+```
+
+## Overview
+
+`sysio::kv::global<Name, T>` stores a single value per contract, keyed by name alone. No scope parameter -- the entry is global to the contract account. Built on format=0 raw KV storage.
+
+Key properties:
+
+- **No scope** -- one value per `Name` per contract, globally accessible
+- **Zero-copy** for `trivially_copyable` types: compile-time `sizeof(T)` buffer, no dynamic allocation
+- Falls back to stack-first serialization for complex types (strings, vectors)
+- Simple API: `set`, `get`, `exists`, `remove`, `get_or_default`, `get_or_create`
+- Multiple globals with different names are independent (`global<"cfg1"_n, T>` vs `global<"cfg2"_n, T>`)
+
+## When to use kv::global
+
+Use `kv::global` when you need:
+- A single configuration or state value per contract (rate limits, feature flags, counters)
+- No scope partitioning -- the value is the same regardless of who calls the contract
+- The simplest possible storage API
+
+Use `singleton` instead if you need scope-based partitioning (different config per scope).
+Use `kv::table` if you need multiple rows or iteration.
+
+## Constructor
+
+```cpp
+kv::global<"config"_n, config_type> cfg(get_self());
+```
+
+- `code` -- the contract account that owns the data (default: current receiver)
+
+## API reference
+
+| Method | Description |
+|--------|-------------|
+| `exists()` | Returns true if a value has been stored |
+| `get(msg)` | Returns stored value, asserts if missing |
+| `get_or_default(def)` | Returns stored value or `def` |
+| `get_or_create(payer, def)` | Returns stored value, or stores and returns `def` |
+| `set(value, payer)` | Stores or overwrites the value |
+| `remove()` | Deletes the stored value (safe to call if not set) |
+
+## Example
+
+```cpp
+#include <sysio/sysio.hpp>
+#include <sysio/kv_global.hpp>
+
+using namespace sysio;
+
+struct app_config {
+   uint64_t max_transfer;
+   uint32_t fee_bps;
+   SYSLIB_SERIALIZE(app_config, (max_transfer)(fee_bps))
+};
+
+class [[sysio::contract]] myapp : public contract {
+public:
+   using contract::contract;
+
+   kv::global<"config"_n, app_config> cfg{get_self()};
+
+   [[sysio::action]]
+   void setconfig(uint64_t max_transfer, uint32_t fee_bps) {
+      require_auth(get_self());
+      cfg.set({max_transfer, fee_bps}, get_self());
+   }
+
+   [[sysio::action]]
+   void transfer(name from, name to, uint64_t amount) {
+      require_auth(from);
+      auto c = cfg.get("config not set");
+      check(amount <= c.max_transfer, "exceeds max transfer");
+      // ... apply fee_bps, do transfer ...
+   }
+};
+```
+
+## Comparison with singleton
+
+| | `kv::global` | `singleton` |
+|---|---|---|
+| Scope | None (global) | Required |
+| Backing | format=0 raw KV | format=1 `kv::table` |
+| Key size | 8 bytes | 24 bytes |
+| Multiple values per contract | One per Name | One per Name per scope |
+| Use case | Contract-wide config | Per-account or per-scope config |

--- a/docs/kv-indexed-table.md
+++ b/docs/kv-indexed-table.md
@@ -112,7 +112,7 @@ tbl.modify(payer, it, new_value);        // explicit payer
 auto next = tbl.erase(std::move(it));
 ```
 
-`modify` takes the new value directly (not a lambda). The old value is read from the iterator's cache to compute secondary key deltas.
+`modify` takes the new value directly (not a lambda). The old value is read from the iterator's stored row to compute secondary key deltas.
 
 **Important:** `emplace` must only be called for keys that do not already exist. Calling `emplace` on an existing key corrupts secondary indexes — the primary value is overwritten but old secondary index entries are orphaned (see below). Use `upsert()` if the key may already exist, or `modify()` when you have an iterator.
 
@@ -172,7 +172,7 @@ for (auto it = idx.key_begin(); it != idx.key_end(); ++it) {
 - **Move-only**: iterators cannot be copied (avoids expensive handle cloning). Post-increment/decrement are deleted -- use `++it` / `--it`
 - **Dereference returns `row`**: `it->key` and `it->value` for both primary and secondary iterators
 - **Bidirectional**: `--end()` gives the last element; `--it` steps backward
-- **Invalidated after mutation**: calling `modify` through a secondary iterator invalidates it — the cached value is stale, and if the secondary key changed, the iterator's position in the index is also invalid (the underlying entry was moved by `kv_idx_update`). Do not dereference or advance the iterator after `modify`; re-find instead. `erase` consumes the iterator and returns the next one, so this does not apply to erase
+- **Invalidated after mutation**: calling `modify` through a secondary iterator invalidates it — the iterator's stored value is stale, and if the secondary key changed, the iterator's position in the index is also invalid (the underlying entry was moved by `kv_idx_update`). Do not dereference or advance the iterator after `modify`; re-find instead. `erase` consumes the iterator and returns the next one, so this does not apply to erase
 
 ## Extractor consistency note
 

--- a/docs/kv-multi-index.md
+++ b/docs/kv-multi-index.md
@@ -1,5 +1,7 @@
 # sysio::multi\_index
 
+> **Backward compatibility only.** For new contracts, use [`kv::table`](kv-table.md) (no secondary indices), [`kv::indexed_table`](kv-indexed-table.md) (with secondary indices), [`kv::global`](kv-global.md) (non-scoped singleton), or [`singleton`](kv-table.md#singleton) (scoped singleton). See [why upgrade](kv-storage-guide.md#why-upgrade-from-multi_index) for the full comparison.
+
 ## Include
 
 ```cpp
@@ -10,7 +12,7 @@
 
 ## Overview
 
-The API surface is identical to the EOSIO `multi_index`. Under the hood, primary rows are stored as 24-byte KV keys and secondary indices use the `kv_idx_*` intrinsics, but from the contract author's perspective the interface is the same.
+`sysio::multi_index` is a drop-in replacement for the EOSIO `multi_index`. Existing contracts compile and run unchanged. Under the hood, primary rows are stored as 24-byte KV keys and secondary indices use the `kv_idx_*` intrinsics, but from the contract author's perspective the interface is the same.
 
 Key properties:
 

--- a/docs/kv-storage-guide.md
+++ b/docs/kv-storage-guide.md
@@ -125,7 +125,99 @@ At the OC (Optimized Compiler) runtime tier, intrinsic call overhead dominates a
 - **Use `lower_bound` instead of scanning** -- `lower_bound(start_key)` + iterate is much faster than scanning from `begin()`
 - **Use key-only iteration** for scanning -- `indexed_table`'s `key_begin()`/`key_end()` avoids value deserialization
 - **Use `indexed_table` for new contracts** -- format=0 keys save 16 bytes per row vs format=1
-- **Use POD value types** -- all table APIs use zero-copy (memcpy) for `trivially_copyable` values, eliminating serialization overhead
+- **Use POD value types** -- all table APIs use zero-copy (memcpy) for `trivially_copyable` values, eliminating serialization overhead (see [zero-copy optimization](#zero-copy-optimization) below)
+
+### Key Size Limit (`KV_KEY_BUF_CAP`)
+
+Format=0 keys (`raw_table`, `indexed_table`) are encoded on the stack via `be_key_stream`, which uses a fixed buffer. The default capacity is **256 bytes**, matching the default chain `max_kv_key_size`. Keys that exceed this limit will abort with `"be_key_stream: key too large"`.
+
+To increase the limit (e.g., for contracts with long string keys), pass `-DKV_KEY_BUF_CAP=512` to `cdt-cpp`. The chain supports up to 1024 bytes.
+
+```bash
+cdt-cpp -DKV_KEY_BUF_CAP=512 -abigen -o mycontract.wasm mycontract.cpp
+```
+
+**Stack usage note:** Each `be_key_stream` instance uses `KV_KEY_BUF_CAP` bytes on the WASM stack. Contracts with many secondary indices create one instance per index during `emplace`/`modify`/`erase`. With 16 indices at `KV_KEY_BUF_CAP=256`, this is ~4KB of the default 8KB WASM stack. If you increase the buffer and have many indices, you may also need to increase the WASM stack size.
+
+Format=1 keys (`kv::table`, `multi_index`) use fixed 24-byte keys and are not affected by this limit.
+
+### Zero-Copy Serialization
+
+All table APIs automatically use zero-copy `memcpy` serialization for value types that satisfy two compile-time conditions:
+
+1. `std::is_trivially_copyable<T>` — no `std::string`, `std::vector`, `std::optional`, virtual functions, or non-trivial constructors/destructors
+2. `sizeof(T) == pack_size(T{})` — no struct padding (the raw memory layout matches the serialized field layout)
+
+When both conditions hold, `sysio::kv::is_fixed_serializable_v<T>` is `true` and the compiler generates a single code path using a fixed `char[sizeof(T)]` stack buffer and `memcpy` — no dynamic allocation, no size probing, exactly one host call per read or write.
+
+Types that don't qualify fall back to field-by-field datastream serialization with a stack-first buffer (`kv_value_stack_size` = 256 bytes inline, heap fallback for larger values). This is still efficient but involves per-field encoding/decoding and may require a size-probe host call.
+
+#### Verifying your type qualifies
+
+Use `static_assert` with `is_fixed_serializable_v`. The assert **must be placed after the class definition**, not inside it. The `SYSLIB_SERIALIZE` macro generates `constexpr` friend operators that are only visible via argument-dependent lookup (ADL) after the enclosing class is complete. A `static_assert` inside the class body will always evaluate to `false` because the operators aren't defined yet at that point.
+
+```cpp
+class [[sysio::contract]] mycontract : public contract {
+public:
+   using contract::contract;
+
+   struct balance_row {
+      uint64_t account;
+      uint64_t amount;
+      uint64_t primary_key() const { return account; }
+      SYSLIB_SERIALIZE(balance_row, (account)(amount))
+   };
+
+   // WRONG — always fails inside the class body:
+   // static_assert(kv::is_fixed_serializable_v<balance_row>, "...");
+
+   // ... actions ...
+};
+
+// CORRECT — after the closing brace of the class:
+static_assert(sysio::kv::is_fixed_serializable_v<mycontract::balance_row>,
+              "balance_row should qualify for zero-copy serialization");
+```
+
+#### When the check fails: struct padding
+
+The most common reason `is_fixed_serializable_v` is `false` for an all-POD struct is **trailing padding**. The compiler inserts padding bytes at the end of a struct to satisfy the alignment requirement of the largest member:
+
+```cpp
+struct row {
+   uint64_t id;     // 8 bytes at offset 0
+   uint32_t flags;  // 4 bytes at offset 8
+   // 4 bytes PADDING inserted here to align struct to 8 bytes
+};
+// sizeof(row) = 16, pack_size(row{}) = 12 (only the actual fields)
+// is_fixed_serializable_v<row> = false
+```
+
+The zero-copy path stores `sizeof(T)` bytes via `memcpy`. If `sizeof != pack_size`, the stored data would include uninitialized padding bytes that don't correspond to any field.
+
+#### Enabling zero-copy for padded structs
+
+Add an explicit padding field so that `sizeof == pack_size`:
+
+```cpp
+struct row {
+   uint64_t id;
+   uint32_t flags;
+   uint32_t _padding = 0;  // fills the 4-byte gap
+   SYSLIB_SERIALIZE(row, (id)(flags)(_padding))
+};
+// sizeof(row) = 16, pack_size(row{}) = 16
+// is_fixed_serializable_v<row> = true
+```
+
+**The tradeoff:** The padding field costs extra bytes of RAM per row stored on-chain. In this example, 4 bytes per row. For tables with millions of rows this adds up. For small tables, singletons, or globals the cost is negligible.
+
+| Approach | RAM per row | Serialization | Host calls per read |
+|----------|------------|---------------|---------------------|
+| No padding (datastream fallback) | Compact — only field bytes | Field-by-field encode/decode | 1-2 (size probe + read if value > stack buffer) |
+| Explicit padding (zero-copy) | +N padding bytes | Single `memcpy` | 1 (exact `sizeof(T)` buffer) |
+
+**When zero-copy matters most:** Contracts that do heavy iteration (scanning tables, bulk reads in a loop) benefit from eliminating per-field serialization and guaranteeing a single host call per row. Contracts that mostly do point lookups on small tables will see negligible difference — the host call overhead dominates either way.
 
 ---
 

--- a/docs/kv-storage-guide.md
+++ b/docs/kv-storage-guide.md
@@ -1,11 +1,18 @@
 # Wire KV Storage Guide
 
-Wire uses a key-value database as the storage backend for smart contract state, replacing the EOSIO `db_*_i64` host functions with a simpler set of KV intrinsics. Four C++ APIs are available to contract developers:
+Wire uses a key-value database as the storage backend for smart contract state, replacing the EOSIO `db_*_i64` host functions with a simpler set of KV intrinsics. Five C++ APIs are available to contract developers:
 
-- **[`sysio::multi_index`](kv-multi-index.md)** -- Full-featured table with secondary indices, reverse iteration, object caching, and singletons. API-compatible with EOSIO `multi_index`. Recommended for migrating existing contracts.
-- **[`sysio::kv::indexed_table`](kv-indexed-table.md)** -- Compact format=0 keys with secondary indices. No legacy scope overhead. Recommended for new contracts that need secondary lookups.
-- **[`sysio::kv::table`](kv-table.md)** -- High-performance table for simple CRUD workloads. No secondary index support. Scope-based partitioning with cross-scope iteration.
-- **[`sysio::kv::raw_table`](kv-raw-table.md)** -- Low-level ordered key-value store with custom keys. No secondary indices, no scope. For contracts that need direct byte-level key control.
+### Recommended for new contracts
+
+- **[`sysio::kv::table`](kv-table.md)** -- High-performance table with scope-based partitioning and cross-scope iteration. No secondary indices. Includes **[`sysio::singleton`](kv-table.md#singleton)** support.
+- **[`sysio::kv::indexed_table`](kv-indexed-table.md)** -- Compact format=0 keys with secondary indices. No legacy scope overhead. Best choice when secondary lookups are needed.
+- **[`sysio::kv::global`](kv-global.md)** -- Non-scoped singleton for contract-wide config/state. One value per name, no scope parameter. Simplest storage API.
+- **[`sysio::kv::raw_table`](kv-raw-table.md)** -- Low-level ordered key-value store with custom compound keys. For contracts that need direct byte-level key control.
+
+### Backward compatibility
+
+- **[`sysio::multi_index`](kv-multi-index.md)** -- Drop-in replacement for the EOSIO `multi_index`. API-compatible so existing contracts compile unchanged. **For new contracts, prefer the APIs above** (see [why upgrade](#why-upgrade-from-multi_index) below).
+- **[`sysio::singleton`](kv-table.md#singleton)** -- Drop-in replacement for the EOSIO `singleton`. Backed by `kv::table`. **For new contracts that don't need scope, prefer [`kv::global`](kv-global.md)**.
 
 All APIs use the same underlying KV host functions (intrinsics). Existing EOSIO contracts compile unchanged with the new CDT -- no source code modifications required.
 
@@ -13,29 +20,32 @@ All APIs use the same underlying KV host functions (intrinsics). Existing EOSIO 
 
 ## Choosing Between APIs
 
-| Feature | multi\_index | indexed\_table | kv::table | raw\_table |
-|---------|-------------|---------------|-----------|-----------|
-| Key format | Format=1 (24B) | Format=0 (compact) | Format=1 (24B) | Format=0 (compact) |
-| Scope | Yes | No | Yes | No |
-| Secondary indices | Yes (up to 16) | Yes (up to 16) | No | No |
-| Key type | `uint64_t` | Custom struct | `uint64_t` | Custom struct |
-| Value type | Unified row `T` | Separate `K`, `V` | Unified row `T` | Separate `K`, `V` |
-| Mutation style | Lambda | Direct value | Lambda | Direct set |
-| Object caching | Yes | No | No | No |
-| Zero-copy for POD values | Yes | Yes | Yes | Yes |
-| Cross-scope iteration | No | N/A (no scope) | Yes | N/A (no scope) |
-| Key-only sec. iteration | No | Yes | N/A | N/A |
-| Payer parameter | Required (first arg) | Optional (overloads) | Required | Optional (default) |
-| EOSIO compatible | Yes (drop-in) | No | No | No |
+| Feature | multi\_index | indexed\_table | kv::table | raw\_table | singleton | kv::global |
+|---------|-------------|---------------|-----------|-----------|-----------|------------|
+| Key format | Format=1 (24B) | Format=0 (compact) | Format=1 (24B) | Format=0 (compact) | Format=1 (24B) | Format=0 (8B) |
+| Scope | Yes | No | Yes | No | Yes | No |
+| Secondary indices | Yes (up to 16) | Yes (up to 16) | No | No | No | No |
+| Key type | `uint64_t` | Custom struct | `uint64_t` | Custom struct | Fixed (pk=0) | Fixed (name) |
+| Value type | Unified row `T` | Separate `K`, `V` | Unified row `T` | Separate `K`, `V` | `T` | `T` |
+| Mutation style | Lambda | Direct value | Lambda | Direct set | `set(val, payer)` | `set(val, payer)` |
+| Object caching | Yes | No | No | No | No | No |
+| Zero-copy for POD values | Yes | Yes | Yes | Yes | Yes | Yes |
+| Cross-scope iteration | No | N/A (no scope) | Yes | N/A (no scope) | N/A | N/A |
+| Key-only sec. iteration | No | Yes | N/A | N/A | N/A | N/A |
+| Heap-free hot path (POD) | No | Yes | Yes | Yes | Yes | Yes |
+| Payer parameter | Required (first arg) | Optional (overloads) | Required | Optional (default) | Required | Required |
+| EOSIO compatible | Yes (drop-in) | No | No | No | Yes (drop-in) | No |
 
 **Decision matrix:**
 
-- Migrating an existing EOSIO contract? Use **[multi\_index](kv-multi-index.md)** (zero code changes).
-- New contract needing secondary indices? Use **[indexed\_table](kv-indexed-table.md)** (compact keys, no scope waste).
-- Maximum throughput on simple reads/writes with POD structs and scope-based partitioning? Use **[kv::table](kv-table.md)**.
+- Migrating an existing EOSIO contract with no code changes? Use **[multi\_index](kv-multi-index.md)** (drop-in).
+- New contract needing secondary indices? Use **[indexed\_table](kv-indexed-table.md)**.
+- Simple table with scope-based partitioning, no secondary indices? Use **[kv::table](kv-table.md)**.
 - Need to iterate across all scopes? Use **[kv::table](kv-table.md)** (`begin_all_scopes`).
-- Need a simple ordered key-value store with custom keys, no indices? Use **[raw\_table](kv-raw-table.md)**.
-- Not sure? Start with **[multi\_index](kv-multi-index.md)** or **[indexed\_table](kv-indexed-table.md)**.
+- Need a single config/state value per scope? Use **[singleton](kv-table.md#singleton)** (built on `kv::table`).
+- Need a single contract-wide config with no scope? Use **[kv::global](kv-global.md)** (simplest API, 8-byte key).
+- Need a simple ordered key-value store with custom compound keys? Use **[raw\_table](kv-raw-table.md)**.
+- Not sure? Start with **[kv::table](kv-table.md)** or **[indexed\_table](kv-indexed-table.md)**.
 
 ---
 
@@ -142,6 +152,25 @@ If you want to switch an existing contract to `indexed_table` for compact keys:
 4. Replace lambda-based `emplace`/`modify` with direct-value calls
 5. Note: existing on-chain data uses format=1 keys. Migrating requires re-inserting all rows in format=0
 
+### From multi\_index to kv::table (no secondary indices)
+
+If your contract uses `multi_index` but does not need secondary indices:
+
+1. Change `#include <sysio/multi_index.hpp>` to `#include <sysio/kv_table.hpp>`
+2. Replace `multi_index<"tbl"_n, T>` with `kv::table<"tbl"_n, T>`
+3. The `emplace`/`modify`/`erase`/`find` API is the same
+4. `get()` returns `T` by value instead of `const T&` (no object caching)
+5. Bonus: `begin_all_scopes()` for cross-scope iteration
+
+### From singleton to kv::global (no scope needed)
+
+If your singleton stores contract-wide config that doesn't vary by scope:
+
+1. Change `#include <sysio/singleton.hpp>` to `#include <sysio/kv_global.hpp>`
+2. Replace `singleton<"cfg"_n, T> cfg(get_self(), get_self().value)` with `kv::global<"cfg"_n, T> cfg(get_self())`
+3. Same API: `set`, `get`, `exists`, `remove`, `get_or_default`, `get_or_create`
+4. No scope parameter -- simpler and 16 bytes less key overhead per entry
+
 ### From raw\_table to indexed\_table
 
 If you started with `raw_table` and need secondary indices:
@@ -151,3 +180,30 @@ If you started with `raw_table` and need secondary indices:
 3. Replace `set(key, value)` with `emplace(key, value)` for new rows and `modify(it, value)` for updates
 4. Note: `indexed_table` has no raw `set()` -- this prevents secondary index corruption
 5. Existing format=0 data is compatible (same key encoding). Add secondary indices by re-inserting rows
+
+---
+
+## Why Upgrade from multi\_index
+
+`sysio::multi_index` is provided for backward compatibility with existing EOSIO contracts. It works correctly but carries overhead that the newer APIs avoid. For new contracts, prefer `kv::table`, `kv::indexed_table`, `kv::global`, or `kv::raw_table`.
+
+**Benefits of upgrading:**
+
+| | multi\_index | New APIs |
+|---|---|---|
+| **Heap allocations per operation** | `std::map` cache + `std::unique_ptr` per row + `std::vector<char>` for serialization | Zero for trivially-copyable types; stack-first for others |
+| **Template instantiation cost** | Pulls in `<map>`, `<memory>`, `<vector>` | Minimal headers; `kv::global` needs only `<cstring>` |
+| **Object caching** | `std::map` cache grows unbounded within an action | No cache; each read goes to KV (fast with OC runtime) |
+| **Serialization for POD types** | Runtime `if (sizeof == pack_size)` check | Compile-time `is_fixed_serializable_v` -- zero branching, exact `sizeof(T)` buffer |
+| **Host calls per read** | 2 (probe size + read) on cache miss | 1 for trivially-copyable; 1-2 for others (stack-buffer-first) |
+| **Host calls per iteration step** | 2 (key read + value read) on cache miss | 1-2 (stack-buffer-first for both key and value) |
+| **Key overhead** | 24B fixed (format=1) | 24B (`kv::table`) or as small as needed (`indexed_table`, `raw_table`, `kv::global` = 8B) |
+| **Cross-scope iteration** | Not possible | `kv::table::begin_all_scopes()` |
+| **Key-only secondary iteration** | Not possible | `indexed_table::key_begin()` / `key_end()` |
+| **Iterator safety** | `const T*` into cache -- invalidated by erase on copied iterator | `T` by value in iterator -- each copy is independent |
+
+**When to keep multi\_index:**
+
+- Drop-in compatibility is required (no code changes)
+- Contract relies on object caching semantics (holding `const T&` across multiple `get()` calls on the same table instance)
+- Contract uses `iterator_to()` to map a cached object back to an iterator

--- a/docs/kv-table.md
+++ b/docs/kv-table.md
@@ -55,17 +55,9 @@ kv::table<"balances"_n, balance_row> bal(code, scope);
 | `available_primary_key()` | Next auto-increment key |
 | `begin_all_scopes()` / `end_all_scopes()` | Iterate ALL rows across ALL scopes (returns `scoped_row`) |
 
-## Zero-copy path
+## Zero-copy optimization
 
-When `T` satisfies **both** conditions:
-1. `std::is_trivially_copyable<T>` is true
-2. `sizeof(T) == pack_size(T{})` (no struct padding)
-
-...the check is evaluated at **compile time** via the `is_fixed_serializable_v<T>` trait. The compiler generates a single code path that uses a fixed `char[sizeof(T)]` stack buffer and `memcpy` — no dynamic allocation, no size probing, exactly one host call per read or write.
-
-All table APIs (`kv::table`, `kv::indexed_table`, `kv::raw_table`, `kv::global`, `singleton`, and `multi_index`) use zero-copy for qualifying types. The newer APIs (`kv::table`, `indexed_table`, `raw_table`, `global`) additionally eliminate all heap allocation on the hot path — the `multi_index` compatibility layer still uses `std::map` and `std::unique_ptr` for its object cache.
-
-Types with `std::string`, `std::vector`, `std::optional`, or nested structs cannot use the zero-copy path. They fall back to stack-first serialization (`kv_value_stack_size` = 256 bytes inline, heap fallback for larger values).
+See [Zero-Copy Serialization](kv-storage-guide.md#zero-copy-serialization) in the storage guide. This optimization applies to all table APIs — `kv::table`, `kv::indexed_table`, `kv::raw_table`, `kv::global`, `singleton`, and `multi_index`.
 
 ## Example
 

--- a/docs/kv-table.md
+++ b/docs/kv-table.md
@@ -59,11 +59,13 @@ kv::table<"balances"_n, balance_row> bal(code, scope);
 
 When `T` satisfies **both** conditions:
 1. `std::is_trivially_copyable<T>` is true
-2. `sizeof(T) == pack_size(T)` (no struct padding)
+2. `sizeof(T) == pack_size(T{})` (no struct padding)
 
-...values are stored and loaded via `memcpy` instead of datastream serialization. This eliminates pack/unpack overhead entirely. Note: all four table APIs (`multi_index`, `indexed_table`, `kv::table`, `raw_table`) now use zero-copy for trivially copyable types.
+...the check is evaluated at **compile time** via the `is_fixed_serializable_v<T>` trait. The compiler generates a single code path that uses a fixed `char[sizeof(T)]` stack buffer and `memcpy` — no dynamic allocation, no size probing, exactly one host call per read or write.
 
-Types with `std::string`, `std::vector`, `std::optional`, or nested structs cannot use the zero-copy path and fall back to standard serialization (equivalent performance to `multi_index`).
+All table APIs (`kv::table`, `kv::indexed_table`, `kv::raw_table`, `kv::global`, `singleton`, and `multi_index`) use zero-copy for qualifying types. The newer APIs (`kv::table`, `indexed_table`, `raw_table`, `global`) additionally eliminate all heap allocation on the hot path — the `multi_index` compatibility layer still uses `std::map` and `std::unique_ptr` for its object cache.
+
+Types with `std::string`, `std::vector`, `std::optional`, or nested structs cannot use the zero-copy path. They fall back to stack-first serialization (`kv_value_stack_size` = 256 bytes inline, heap fallback for larger values).
 
 ## Example
 
@@ -119,6 +121,69 @@ public:
       for (auto it = bal.begin_all_scopes(); it != bal.end_all_scopes(); ++it) {
          print("scope=", it->scope, " pk=", it->primary_key, " amount=", it->obj.amount, "\n");
       }
+   }
+};
+```
+
+---
+
+## Singleton
+
+`sysio::singleton<Name, T>` is built on `kv::table` and stores a single value per scope. It is the scoped equivalent of [`kv::global`](kv-global.md).
+
+### Include
+
+```cpp
+#include <sysio/singleton.hpp>
+```
+
+### API reference
+
+| Method | Description |
+|--------|-------------|
+| `exists()` | Returns true if a value has been stored |
+| `get()` | Returns stored value, asserts if missing |
+| `get_or_default(def)` | Returns stored value or `def` |
+| `get_or_create(payer, def)` | Returns stored value, or stores and returns `def` |
+| `set(value, payer)` | Stores or overwrites the value |
+| `remove()` | Deletes the stored value |
+
+### When to use singleton vs kv::global
+
+- **singleton** -- one value per scope. Use when different scopes need different config (e.g., per-account settings).
+- **[kv::global](kv-global.md)** -- one value per contract, no scope. Use for contract-wide config (rate limits, feature flags). Simpler API, smaller key (8B vs 24B).
+
+### Example
+
+```cpp
+#include <sysio/sysio.hpp>
+#include <sysio/singleton.hpp>
+
+using namespace sysio;
+
+struct app_config {
+   uint64_t version;
+   std::string name;
+   SYSLIB_SERIALIZE(app_config, (version)(name))
+};
+
+using config_singleton = singleton<"config"_n, app_config>;
+
+class [[sysio::contract]] myapp : public contract {
+public:
+   using contract::contract;
+
+   [[sysio::action]]
+   void init() {
+      config_singleton cfg(get_self(), get_self().value);
+      cfg.set({1, "myapp"}, get_self());
+   }
+
+   [[sysio::action]]
+   void getver() {
+      config_singleton cfg(get_self(), get_self().value);
+      auto c = cfg.get_or_default({0, ""});
+      print("version: ", c.version);
    }
 };
 ```

--- a/libraries/sysiolib/contracts/sysio/kv_constants.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_constants.hpp
@@ -20,4 +20,8 @@ inline constexpr uint32_t kv_format_standard = 1;
 /// Chain-enforced maximum KV key size in bytes.
 inline constexpr size_t kv_key_max_bytes = 1024;
 
+/// Stack buffer size for value reads/writes. Values up to this size avoid heap allocation.
+/// Only used for non-trivially-copyable types; trivially-copyable types use sizeof(T) directly.
+inline constexpr uint32_t kv_value_stack_size = 256;
+
 } // namespace sysio::kv

--- a/libraries/sysiolib/contracts/sysio/kv_global.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_global.hpp
@@ -62,43 +62,54 @@ public:
 
    /// Returns the stored value. Asserts if not set.
    T get(const char* msg = "global does not exist") const {
-      auto k = make_key();
       T val;
-      if constexpr (is_fixed_serializable_v<T>) {
-         char vbuf[sizeof(T)];
-         int32_t sz = ::kv_get(kv_format_raw, code(), k.data, 8, vbuf, sizeof(T));
-         sysio::check(sz >= 0, msg);
-         std::memcpy(&val, vbuf, sizeof(T));
-      } else {
-         char stack[kv_value_stack_size];
-         int32_t sz = ::kv_get(kv_format_raw, code(), k.data, 8, stack, kv_value_stack_size);
-         sysio::check(sz >= 0, msg);
-         if (sz <= static_cast<int32_t>(kv_value_stack_size)) {
-            sysio::datastream<const char*> ds(stack, sz);
-            ds >> val;
-         } else {
-            char* heap = new char[sz];
-            ::kv_get(kv_format_raw, code(), k.data, 8, heap, sz);
-            sysio::datastream<const char*> ds(heap, sz);
-            ds >> val;
-            delete[] heap;
-         }
-      }
+      sysio::check(try_get(val), msg);
       return val;
    }
 
    /// Returns the stored value, or \p def if not set.
    T get_or_default(const T& def) const {
-      if (!exists()) return def;
-      return get();
+      T val;
+      if (try_get(val)) return val;
+      return def;
    }
 
    /// Returns the stored value if it exists. Otherwise stores \p def and returns it.
    T get_or_create(sysio::name payer, const T& def) {
-      if (exists()) return get();
+      T val;
+      if (try_get(val)) return val;
       set(def, payer);
       return def;
    }
+
+private:
+   /// Single kv_get call — returns true if found, populates \p out.
+   bool try_get(T& out) const {
+      auto k = make_key();
+      if constexpr (is_fixed_serializable_v<T>) {
+         char vbuf[sizeof(T)];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data, 8, vbuf, sizeof(T));
+         if (sz < 0) return false;
+         std::memcpy(&out, vbuf, sizeof(T));
+      } else {
+         char stack[kv_value_stack_size];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data, 8, stack, kv_value_stack_size);
+         if (sz < 0) return false;
+         if (sz <= static_cast<int32_t>(kv_value_stack_size)) {
+            sysio::datastream<const char*> ds(stack, sz);
+            ds >> out;
+         } else {
+            char* heap = new char[sz];
+            ::kv_get(kv_format_raw, code(), k.data, 8, heap, sz);
+            sysio::datastream<const char*> ds(heap, sz);
+            ds >> out;
+            delete[] heap;
+         }
+      }
+      return true;
+   }
+
+public:
 
    /// Stores or overwrites the value.
    void set(const T& val, sysio::name payer) {

--- a/libraries/sysiolib/contracts/sysio/kv_global.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_global.hpp
@@ -1,0 +1,127 @@
+#pragma once
+/**
+ * sysio::kv::global — Non-scoped singleton backed by a single format=0 KV entry.
+ *
+ * Stores exactly one value per contract, keyed by the table name alone.
+ * No scope parameter — the entry is global to the contract account.
+ *
+ * Uses is_fixed_serializable_v<T> for compile-time zero-copy when T is POD.
+ *
+ * Usage:
+ *   struct config {
+ *      uint64_t rate;
+ *      uint32_t flags;
+ *      SYSLIB_SERIALIZE(config, (rate)(flags))
+ *   };
+ *
+ *   kv::global<"config"_n, config> cfg(get_self());
+ *   cfg.set({42, 0xFF}, get_self());
+ *   auto val = cfg.get();
+ */
+
+#include <sysio/kv_raw_table.hpp>   // kv intrinsics, is_fixed_serializable_v, kv_value_stack_size, ser_buf
+#include <sysio/check.hpp>
+#include <sysio/name.hpp>
+#include <sysio/action.hpp>
+
+#include <cstring>
+#include <optional>
+
+namespace sysio { namespace kv {
+
+template<sysio::name::raw Name, typename T>
+class global {
+   static_assert(std::is_default_constructible_v<T>, "global value type must be default constructible");
+
+   uint64_t _code = 0;
+
+   uint64_t code() const { return _code ? _code : sysio::current_receiver().value; }
+
+   // Fixed key: big-endian encoding of the Name.
+   // 8 bytes, deterministic, no scope.
+   struct key_t {
+      char data[8];
+   };
+
+   static key_t make_key() {
+      key_t k;
+      uint64_t v = static_cast<uint64_t>(Name);
+      for (int i = 7; i >= 0; --i) { k.data[i] = static_cast<char>(v & 0xFF); v >>= 8; }
+      return k;
+   }
+
+public:
+   /// Construct a global. Reads/writes against \p code's KV data (default: current contract).
+   global(sysio::name code = sysio::name{}) : _code(code.value) {}
+
+   /// Returns true if a value has been stored.
+   bool exists() const {
+      auto k = make_key();
+      return ::kv_contains(kv_format_raw, code(), k.data, 8) != 0;
+   }
+
+   /// Returns the stored value. Asserts if not set.
+   T get(const char* msg = "global does not exist") const {
+      auto k = make_key();
+      T val;
+      if constexpr (is_fixed_serializable_v<T>) {
+         char vbuf[sizeof(T)];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data, 8, vbuf, sizeof(T));
+         sysio::check(sz >= 0, msg);
+         std::memcpy(&val, vbuf, sizeof(T));
+      } else {
+         char stack[kv_value_stack_size];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data, 8, stack, kv_value_stack_size);
+         sysio::check(sz >= 0, msg);
+         if (sz <= static_cast<int32_t>(kv_value_stack_size)) {
+            sysio::datastream<const char*> ds(stack, sz);
+            ds >> val;
+         } else {
+            char* heap = new char[sz];
+            ::kv_get(kv_format_raw, code(), k.data, 8, heap, sz);
+            sysio::datastream<const char*> ds(heap, sz);
+            ds >> val;
+            delete[] heap;
+         }
+      }
+      return val;
+   }
+
+   /// Returns the stored value, or \p def if not set.
+   T get_or_default(const T& def) const {
+      if (!exists()) return def;
+      return get();
+   }
+
+   /// Returns the stored value if it exists. Otherwise stores \p def and returns it.
+   T get_or_create(sysio::name payer, const T& def) {
+      if (exists()) return get();
+      set(def, payer);
+      return def;
+   }
+
+   /// Stores or overwrites the value.
+   void set(const T& val, sysio::name payer) {
+      auto k = make_key();
+      if constexpr (is_fixed_serializable_v<T>) {
+         char vbuf[sizeof(T)];
+         std::memcpy(vbuf, &val, sizeof(T));
+         ::kv_set(kv_format_raw, payer.value, k.data, 8, vbuf, sizeof(T));
+      } else {
+         uint32_t sz = sysio::pack_size(val);
+         ser_buf buf(sz);
+         sysio::datastream<char*> ds(buf.data(), sz);
+         ds << val;
+         ::kv_set(kv_format_raw, payer.value, k.data, 8, buf.data(), sz);
+      }
+   }
+
+   /// Removes the stored value. Safe to call even if not set.
+   void remove() {
+      if (!exists()) return;
+      auto k = make_key();
+      ::kv_erase(kv_format_raw, k.data, 8);
+   }
+};
+
+}} // namespace sysio::kv

--- a/libraries/sysiolib/contracts/sysio/kv_indexed_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_indexed_table.hpp
@@ -139,8 +139,10 @@ class be_key_reader {
             char next = _data[_pos++];
             if (next == '\0') { out.assign(tmp, n); return; }
             sysio::check(next == '\x01', "be_key_reader: invalid NUL-escape byte");
+            sysio::check(n < be_key_stream::buf_cap, "be_key_reader: string too large");
             tmp[n++] = '\0';
          } else {
+            sysio::check(n < be_key_stream::buf_cap, "be_key_reader: string too large");
             tmp[n++] = c;
          }
       }

--- a/libraries/sysiolib/contracts/sysio/kv_indexed_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_indexed_table.hpp
@@ -129,6 +129,24 @@ class be_key_reader {
       sysio::check(false, "be_key_reader: unterminated NUL-escape string");
    }
 
+   void read_escaped(key_buf& out) {
+      char tmp[be_key_stream::buf_cap];
+      uint32_t n = 0;
+      while (_pos < _size) {
+         char c = _data[_pos++];
+         if (c == '\0') {
+            sysio::check(_pos < _size, "be_key_reader: truncated NUL-escape");
+            char next = _data[_pos++];
+            if (next == '\0') { out.assign(tmp, n); return; }
+            sysio::check(next == '\x01', "be_key_reader: invalid NUL-escape byte");
+            tmp[n++] = '\0';
+         } else {
+            tmp[n++] = c;
+         }
+      }
+      sysio::check(false, "be_key_reader: unterminated NUL-escape string");
+   }
+
 public:
    be_key_reader(const char* data, size_t size) : _data(data), _size(size) {}
 
@@ -210,7 +228,7 @@ public:
    }
 
    be_key_reader& operator>>(std::string& v) {
-      std::vector<char> tmp;
+      key_buf tmp;
       read_escaped(tmp);
       v.assign(tmp.data(), tmp.size());
       return *this;
@@ -253,10 +271,10 @@ class indexed_table {
 
    // --- Key / value encoding helpers ---
 
-   static std::vector<char> make_key(const K& key) {
+   static be_key_stream make_key(const K& key) {
       be_key_stream bs;
       bs << key;
-      return bs.release();
+      return bs;
    }
 
    static K decode_key(const char* data, size_t size) {
@@ -266,16 +284,16 @@ class indexed_table {
       return key;
    }
 
-   static std::vector<char> serialize_value(const V& value) {
+   static ser_buf serialize_value(const V& value) {
       if constexpr (std::is_trivially_copyable<V>::value) {
          if (sizeof(V) == sysio::pack_size(value)) {
-            std::vector<char> buf(sizeof(V));
+            ser_buf buf(sizeof(V));
             std::memcpy(buf.data(), &value, sizeof(V));
             return buf;
          }
       }
-      auto sz = sysio::pack_size(value);
-      std::vector<char> buf(sz);
+      uint32_t sz = sysio::pack_size(value);
+      ser_buf buf(sz);
       sysio::datastream<char*> ds(buf.data(), buf.size());
       ds << value;
       return buf;
@@ -295,10 +313,10 @@ class indexed_table {
    }
 
    template<typename SecKey>
-   static std::vector<char> encode_sec_key(const SecKey& key) {
+   static be_key_stream encode_sec_key(const SecKey& key) {
       be_key_stream bs;
       bs << key;
-      return bs.release();
+      return bs;
    }
 
    template<typename SecKey>
@@ -313,47 +331,49 @@ class indexed_table {
 
    template<size_t N, typename Index, typename... Rest>
    struct secondary_ops {
-      static void store_all(uint64_t payer, const std::vector<char>& pri, const V& value) {
+      static void store_all(uint64_t payer, const char* pri_data, uint32_t pri_size, const V& value) {
          using ext_t = typename Index::secondary_extractor_type;
          ext_t ext;
          auto sec = encode_sec_key(ext(value));
          ::kv_idx_store(payer, static_cast<uint64_t>(TableName), N,
-                        pri.data(), pri.size(), sec.data(), sec.size());
+                        pri_data, pri_size, sec.data(), sec.size());
          if constexpr (sizeof...(Rest) > 0)
-            secondary_ops<N+1, Rest...>::store_all(payer, pri, value);
+            secondary_ops<N+1, Rest...>::store_all(payer, pri_data, pri_size, value);
       }
 
-      static void remove_all(const std::vector<char>& pri, const V& value) {
+      static void remove_all(const char* pri_data, uint32_t pri_size, const V& value) {
          using ext_t = typename Index::secondary_extractor_type;
          ext_t ext;
          auto sec = encode_sec_key(ext(value));
          ::kv_idx_remove(static_cast<uint64_t>(TableName), N,
-                         pri.data(), pri.size(), sec.data(), sec.size());
+                         pri_data, pri_size, sec.data(), sec.size());
          if constexpr (sizeof...(Rest) > 0)
-            secondary_ops<N+1, Rest...>::remove_all(pri, value);
+            secondary_ops<N+1, Rest...>::remove_all(pri_data, pri_size, value);
       }
 
-      static void update_all(uint64_t payer, const std::vector<char>& pri,
+      static void update_all(uint64_t payer, const char* pri_data, uint32_t pri_size,
                               const V& old_val, const V& new_val) {
          using ext_t = typename Index::secondary_extractor_type;
          ext_t ext;
          auto old_sec = encode_sec_key(ext(old_val));
          auto new_sec = encode_sec_key(ext(new_val));
-         if (old_sec != new_sec) {
+         bool same = (old_sec.size() == new_sec.size()) &&
+                     (old_sec.size() == 0 || std::memcmp(old_sec.data(), new_sec.data(), old_sec.size()) == 0);
+         if (!same) {
             ::kv_idx_update(payer, static_cast<uint64_t>(TableName), N,
-                            pri.data(), pri.size(),
+                            pri_data, pri_size,
                             old_sec.data(), old_sec.size(),
                             new_sec.data(), new_sec.size());
          }
          if constexpr (sizeof...(Rest) > 0)
-            secondary_ops<N+1, Rest...>::update_all(payer, pri, old_val, new_val);
+            secondary_ops<N+1, Rest...>::update_all(payer, pri_data, pri_size, old_val, new_val);
       }
    };
 
    struct no_secondary_ops {
-      static void store_all(uint64_t, const std::vector<char>&, const V&) {}
-      static void remove_all(const std::vector<char>&, const V&) {}
-      static void update_all(uint64_t, const std::vector<char>&, const V&, const V&) {}
+      static void store_all(uint64_t, const char*, uint32_t, const V&) {}
+      static void remove_all(const char*, uint32_t, const V&) {}
+      static void update_all(uint64_t, const char*, uint32_t, const V&, const V&) {}
    };
 
    template<typename... Is>
@@ -364,15 +384,15 @@ class indexed_table {
 
    void store_secondaries(uint64_t payer, const K& key, const V& value) {
       auto pri = make_key(key);
-      sec_ops::store_all(payer, pri, value);
+      sec_ops::store_all(payer, pri.data(), pri.size(), value);
    }
    void remove_secondaries(const K& key, const V& value) {
       auto pri = make_key(key);
-      sec_ops::remove_all(pri, value);
+      sec_ops::remove_all(pri.data(), pri.size(), value);
    }
    void update_secondaries(uint64_t payer, const K& key, const V& old_val, const V& new_val) {
       auto pri = make_key(key);
-      sec_ops::update_all(payer, pri, old_val, new_val);
+      sec_ops::update_all(payer, pri.data(), pri.size(), old_val, new_val);
    }
 
    // Internal erase used by both primary and secondary erase paths
@@ -437,19 +457,16 @@ public:
       }
       friend bool operator!=(const const_iterator& a, const const_iterator& b) { return !(a == b); }
 
-      ~const_iterator() { if (_handle >= 0) ::kv_it_destroy(_handle); }
-
       const_iterator(const_iterator&& o) noexcept
-         : _tbl(o._tbl), _handle(o._handle), _valid(o._valid),
+         : _tbl(o._tbl), _handle(std::move(o._handle)), _valid(o._valid),
            _row(std::move(o._row)), _raw_key(std::move(o._raw_key))
-      { o._handle = -1; o._valid = false; }
+      { o._valid = false; }
 
       const_iterator& operator=(const_iterator&& o) noexcept {
          if (this != &o) {
-            if (_handle >= 0) ::kv_it_destroy(_handle);
-            _tbl = o._tbl; _handle = o._handle; _valid = o._valid;
+            _tbl = o._tbl; _handle = std::move(o._handle); _valid = o._valid;
             _row = std::move(o._row); _raw_key = std::move(o._raw_key);
-            o._handle = -1; o._valid = false;
+            o._valid = false;
          }
          return *this;
       }
@@ -460,10 +477,10 @@ public:
    private:
       friend class indexed_table;
       const indexed_table* _tbl = nullptr;
-      int32_t              _handle = -1;
+      kv::detail::it_handle _handle;
       bool                 _valid = false;
       row                  _row;
-      std::vector<char>    _raw_key;
+      key_buf              _raw_key;
 
       const_iterator(const indexed_table* t, int32_t h, bool valid)
          : _tbl(t), _handle(h), _valid(valid) {
@@ -474,27 +491,45 @@ public:
       }
 
       void load() {
-         // Read raw key
+         char key_stack[key_buf::inline_cap];
          uint32_t key_size = 0;
-         ::kv_it_key(_handle, 0, nullptr, 0, &key_size);
-         _raw_key.resize(key_size);
-         if (::kv_it_key(_handle, 0, _raw_key.data(), key_size, &key_size) != 0) {
+         if (::kv_it_key(_handle, 0, key_stack, key_buf::inline_cap, &key_size) != 0) {
             _valid = false; return;
+         }
+         if (key_size <= key_buf::inline_cap) {
+            _raw_key.assign(key_stack, key_size);
+         } else {
+            char* kh = new char[key_size];
+            ::kv_it_key(_handle, 0, kh, key_size, &key_size);
+            _raw_key.assign(kh, key_size);
+            delete[] kh;
          }
          _row.key = decode_key(_raw_key.data(), _raw_key.size());
 
-         // Read and deserialize value
-         uint32_t val_size = 0;
-         ::kv_it_value(_handle, 0, nullptr, 0, &val_size);
-         std::vector<char> vbuf(val_size);
-         ::kv_it_value(_handle, 0, vbuf.data(), val_size, &val_size);
-         _row.value = deserialize_value(vbuf.data(), vbuf.size());
+         if constexpr (is_fixed_serializable_v<V>) {
+            char vbuf[sizeof(V)];
+            uint32_t val_size = 0;
+            ::kv_it_value(_handle, 0, vbuf, sizeof(V), &val_size);
+            std::memcpy(&_row.value, vbuf, sizeof(V));
+         } else {
+            char val_stack[kv_value_stack_size];
+            uint32_t val_size = 0;
+            ::kv_it_value(_handle, 0, val_stack, 256, &val_size);
+            if (val_size <= kv_value_stack_size) {
+               _row.value = deserialize_value(val_stack, val_size);
+            } else {
+               char* heap = new char[val_size];
+               ::kv_it_value(_handle, 0, heap, val_size, &val_size);
+               _row.value = deserialize_value(heap, val_size);
+               delete[] heap;
+            }
+         }
       }
 
       void ensure_handle() {
          if (_handle >= 0) return;
          if (!_tbl) return;
-         _handle = ::kv_it_create(kv_format_raw, _tbl->code(), nullptr, 0);
+         _handle.reset(::kv_it_create(kv_format_raw, _tbl->code(), nullptr, 0));
          if (_valid && !_raw_key.empty())
             ::kv_it_lower_bound(_handle, _raw_key.data(), _raw_key.size());
       }
@@ -526,11 +561,24 @@ public:
 
    std::optional<V> get(const K& key) const {
       auto k = make_key(key);
-      int32_t sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), nullptr, 0);
-      if (sz < 0) return {};
-      std::vector<char> buf(sz);
-      ::kv_get(kv_format_raw, code(), k.data(), k.size(), buf.data(), buf.size());
-      return deserialize_value(buf.data(), buf.size());
+      if constexpr (is_fixed_serializable_v<V>) {
+         char vbuf[sizeof(V)];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), vbuf, sizeof(V));
+         if (sz < 0) return {};
+         V val; std::memcpy(&val, vbuf, sizeof(V));
+         return val;
+      } else {
+         char stack[kv_value_stack_size];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), stack, kv_value_stack_size);
+         if (sz < 0) return {};
+         if (sz <= static_cast<int32_t>(kv_value_stack_size))
+            return deserialize_value(stack, sz);
+         char* heap = new char[sz];
+         ::kv_get(kv_format_raw, code(), k.data(), k.size(), heap, sz);
+         V result = deserialize_value(heap, sz);
+         delete[] heap;
+         return result;
+      }
    }
 
    bool contains(const K& key) const {
@@ -547,7 +595,8 @@ public:
 
    const_iterator upper_bound(const K& key) const {
       auto it = lower_bound(key);
-      if (it != end() && it._raw_key == make_key(key)) ++it;
+      auto encoded = make_key(key);
+      if (it != end() && it._raw_key.equals(encoded.data(), encoded.size())) ++it;
       return it;
    }
 
@@ -559,8 +608,14 @@ public:
    /// or modify() to update via an iterator.
    void emplace(name payer, const K& key, const V& value) {
       auto k = make_key(key);
-      auto v = serialize_value(value);
-      ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+      if constexpr (is_fixed_serializable_v<V>) {
+         char vbuf[sizeof(V)];
+         std::memcpy(vbuf, &value, sizeof(V));
+         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+      } else {
+         auto v = serialize_value(value);
+         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+      }
       store_secondaries(payer.value, key, value);
    }
 
@@ -574,19 +629,38 @@ public:
    /// path to check for existence.
    void upsert(name payer, const K& key, const V& value) {
       auto k = make_key(key);
-      int32_t old_sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), nullptr, 0);
-      if (old_sz >= 0) {
-         // Key exists — read old value for secondary index update
-         std::vector<char> old_buf(old_sz);
-         ::kv_get(kv_format_raw, code(), k.data(), k.size(), old_buf.data(), old_buf.size());
-         V old_value = deserialize_value(old_buf.data(), old_buf.size());
-         update_secondaries(payer.value, key, old_value, value);
+      if constexpr (is_fixed_serializable_v<V>) {
+         char old_vbuf[sizeof(V)];
+         int32_t old_sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), old_vbuf, sizeof(V));
+         if (old_sz >= 0) {
+            V old_value; std::memcpy(&old_value, old_vbuf, sizeof(V));
+            update_secondaries(payer.value, key, old_value, value);
+         } else {
+            store_secondaries(payer.value, key, value);
+         }
+         char vbuf[sizeof(V)];
+         std::memcpy(vbuf, &value, sizeof(V));
+         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), vbuf, sizeof(V));
       } else {
-         // New key — store secondary entries
-         store_secondaries(payer.value, key, value);
+         char stack[kv_value_stack_size];
+         int32_t old_sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), stack, kv_value_stack_size);
+         if (old_sz >= 0) {
+            const char* old_data = stack;
+            char* heap = nullptr;
+            if (old_sz > static_cast<int32_t>(kv_value_stack_size)) {
+               heap = new char[old_sz];
+               ::kv_get(kv_format_raw, code(), k.data(), k.size(), heap, old_sz);
+               old_data = heap;
+            }
+            V old_value = deserialize_value(old_data, old_sz);
+            delete[] heap;
+            update_secondaries(payer.value, key, old_value, value);
+         } else {
+            store_secondaries(payer.value, key, value);
+         }
+         auto v = serialize_value(value);
+         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
       }
-      auto v = serialize_value(value);
-      ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
    }
 
    void upsert(const K& key, const V& value) {
@@ -596,9 +670,15 @@ public:
    void modify(name payer, const const_iterator& it, const V& new_value) {
       sysio::check(it._valid, "cannot modify end iterator");
       auto k = make_key(it._row.key);
-      auto v = serialize_value(new_value);
       update_secondaries(payer.value, it._row.key, it._row.value, new_value);
-      ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+      if constexpr (is_fixed_serializable_v<V>) {
+         char vbuf[sizeof(V)];
+         std::memcpy(vbuf, &new_value, sizeof(V));
+         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+      } else {
+         auto v = serialize_value(new_value);
+         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+      }
    }
 
    void modify(const const_iterator& it, const V& new_value) {
@@ -672,9 +752,9 @@ public:
             if (_handle < 0) {
                char max_sec[kv_key_max_bytes];
                memset(max_sec, 0xFF, sizeof(max_sec));
-               _handle = ::kv_idx_lower_bound(
+               _handle.reset(::kv_idx_lower_bound(
                   _tbl->code(), static_cast<uint64_t>(TableName), index_number,
-                  max_sec, sizeof(max_sec));
+                  max_sec, sizeof(max_sec)));
                if (_handle < 0) { _valid = false; }
                else if (::kv_idx_prev(_handle) == 0) { _valid = true; load_current(); }
                else { _valid = false; }
@@ -695,17 +775,15 @@ public:
          }
          friend bool operator!=(const const_iterator& a, const const_iterator& b) { return !(a == b); }
 
-         ~const_iterator() { if (_handle >= 0) ::kv_idx_destroy(_handle); }
          const_iterator(const_iterator&& o) noexcept
-            : _tbl(o._tbl), _handle(o._handle), _valid(o._valid),
+            : _tbl(o._tbl), _handle(std::move(o._handle)), _valid(o._valid),
               _row(std::move(o._row)), _pri_bytes(std::move(o._pri_bytes))
-         { o._handle = -1; o._valid = false; }
+         { o._valid = false; }
          const_iterator& operator=(const_iterator&& o) noexcept {
             if (this != &o) {
-               if (_handle >= 0) ::kv_idx_destroy(_handle);
-               _tbl = o._tbl; _handle = o._handle; _valid = o._valid;
+               _tbl = o._tbl; _handle = std::move(o._handle); _valid = o._valid;
                _row = std::move(o._row); _pri_bytes = std::move(o._pri_bytes);
-               o._handle = -1; o._valid = false;
+               o._valid = false;
             }
             return *this;
          }
@@ -715,10 +793,10 @@ public:
       private:
          friend struct secondary_index_view;
          indexed_table* _tbl = nullptr;
-         int32_t        _handle = -1;
+         kv::detail::idx_handle _handle;
          bool           _valid = false;
          row            _row;
-         std::vector<char> _pri_bytes;
+         key_buf        _pri_bytes;
 
          const_iterator(indexed_table* tbl, int32_t handle, bool valid)
             : _tbl(tbl), _handle(handle), _valid(valid) {
@@ -730,23 +808,44 @@ public:
 
          void load_current() {
             if (_handle < 0) { _valid = false; return; }
-            // Read primary key bytes
+            char pri_stack[key_buf::inline_cap];
             uint32_t pri_size = 0;
-            ::kv_idx_primary_key(_handle, 0, nullptr, 0, &pri_size);
-            _pri_bytes.resize(pri_size);
-            if (::kv_idx_primary_key(_handle, 0, _pri_bytes.data(), pri_size, &pri_size) != 0) {
+            if (::kv_idx_primary_key(_handle, 0, pri_stack, key_buf::inline_cap, &pri_size) != 0) {
                _valid = false; return;
+            }
+            if (pri_size <= key_buf::inline_cap) {
+               _pri_bytes.assign(pri_stack, pri_size);
+            } else {
+               char* ph = new char[pri_size];
+               ::kv_idx_primary_key(_handle, 0, ph, pri_size, &pri_size);
+               _pri_bytes.assign(ph, pri_size);
+               delete[] ph;
             }
             _row.key = decode_key(_pri_bytes.data(), _pri_bytes.size());
 
-            // Fetch the full value via primary key lookup
-            int32_t val_sz = ::kv_get(kv_format_raw, _tbl->code(),
-                                      _pri_bytes.data(), _pri_bytes.size(), nullptr, 0);
-            if (val_sz < 0) { _valid = false; return; }
-            std::vector<char> vbuf(val_sz);
-            ::kv_get(kv_format_raw, _tbl->code(),
-                     _pri_bytes.data(), _pri_bytes.size(), vbuf.data(), vbuf.size());
-            _row.value = deserialize_value(vbuf.data(), vbuf.size());
+            if constexpr (is_fixed_serializable_v<V>) {
+               char vbuf[sizeof(V)];
+               int32_t val_sz = ::kv_get(kv_format_raw, _tbl->code(),
+                                         _pri_bytes.data(), _pri_bytes.size(),
+                                         vbuf, sizeof(V));
+               if (val_sz < 0) { _valid = false; return; }
+               std::memcpy(&_row.value, vbuf, sizeof(V));
+            } else {
+               char val_stack[kv_value_stack_size];
+               int32_t val_sz = ::kv_get(kv_format_raw, _tbl->code(),
+                                         _pri_bytes.data(), _pri_bytes.size(),
+                                         val_stack, kv_value_stack_size);
+               if (val_sz < 0) { _valid = false; return; }
+               if (val_sz <= static_cast<int32_t>(kv_value_stack_size)) {
+                  _row.value = deserialize_value(val_stack, val_sz);
+               } else {
+                  char* heap = new char[val_sz];
+                  ::kv_get(kv_format_raw, _tbl->code(),
+                           _pri_bytes.data(), _pri_bytes.size(), heap, val_sz);
+                  _row.value = deserialize_value(heap, val_sz);
+                  delete[] heap;
+               }
+            }
          }
       };
 
@@ -774,9 +873,9 @@ public:
             if (_handle < 0) {
                char max_sec[kv_key_max_bytes];
                memset(max_sec, 0xFF, sizeof(max_sec));
-               _handle = ::kv_idx_lower_bound(
+               _handle.reset(::kv_idx_lower_bound(
                   _tbl->code(), static_cast<uint64_t>(TableName), index_number,
-                  max_sec, sizeof(max_sec));
+                  max_sec, sizeof(max_sec)));
                if (_handle < 0) { _valid = false; }
                else if (::kv_idx_prev(_handle) == 0) { _valid = true; load_keys(); }
                else { _valid = false; }
@@ -797,17 +896,15 @@ public:
          }
          friend bool operator!=(const key_iterator& a, const key_iterator& b) { return !(a == b); }
 
-         ~key_iterator() { if (_handle >= 0) ::kv_idx_destroy(_handle); }
          key_iterator(key_iterator&& o) noexcept
-            : _tbl(o._tbl), _handle(o._handle), _valid(o._valid),
+            : _tbl(o._tbl), _handle(std::move(o._handle)), _valid(o._valid),
               _kr(std::move(o._kr)), _pri_bytes(std::move(o._pri_bytes))
-         { o._handle = -1; o._valid = false; }
+         { o._valid = false; }
          key_iterator& operator=(key_iterator&& o) noexcept {
             if (this != &o) {
-               if (_handle >= 0) ::kv_idx_destroy(_handle);
-               _tbl = o._tbl; _handle = o._handle; _valid = o._valid;
+               _tbl = o._tbl; _handle = std::move(o._handle); _valid = o._valid;
                _kr = std::move(o._kr); _pri_bytes = std::move(o._pri_bytes);
-               o._handle = -1; o._valid = false;
+               o._valid = false;
             }
             return *this;
          }
@@ -817,10 +914,10 @@ public:
       private:
          friend struct secondary_index_view;
          indexed_table* _tbl = nullptr;
-         int32_t        _handle = -1;
+         kv::detail::idx_handle _handle;
          bool           _valid = false;
          key_row        _kr;
-         std::vector<char> _pri_bytes;
+         key_buf        _pri_bytes;
 
          key_iterator(indexed_table* tbl, int32_t handle, bool valid)
             : _tbl(tbl), _handle(handle), _valid(valid) {
@@ -832,21 +929,32 @@ public:
 
          void load_keys() {
             if (_handle < 0) { _valid = false; return; }
-            // Read primary key
+            char pri_stack[key_buf::inline_cap];
             uint32_t pri_size = 0;
-            ::kv_idx_primary_key(_handle, 0, nullptr, 0, &pri_size);
-            _pri_bytes.resize(pri_size);
-            if (::kv_idx_primary_key(_handle, 0, _pri_bytes.data(), pri_size, &pri_size) != 0) {
+            if (::kv_idx_primary_key(_handle, 0, pri_stack, key_buf::inline_cap, &pri_size) != 0) {
                _valid = false; return;
+            }
+            if (pri_size <= key_buf::inline_cap) {
+               _pri_bytes.assign(pri_stack, pri_size);
+            } else {
+               char* ph = new char[pri_size];
+               ::kv_idx_primary_key(_handle, 0, ph, pri_size, &pri_size);
+               _pri_bytes.assign(ph, pri_size);
+               delete[] ph;
             }
             _kr.key = decode_key(_pri_bytes.data(), _pri_bytes.size());
 
-            // Read secondary key
+            char sec_stack[64];
             uint32_t sec_size = 0;
-            ::kv_idx_key(_handle, 0, nullptr, 0, &sec_size);
-            std::vector<char> sec_buf(sec_size);
-            ::kv_idx_key(_handle, 0, sec_buf.data(), sec_size, &sec_size);
-            _kr.sec_key = decode_sec_key<secondary_key_type>(sec_buf.data(), sec_buf.size());
+            ::kv_idx_key(_handle, 0, sec_stack, 64, &sec_size);
+            if (sec_size <= 64) {
+               _kr.sec_key = decode_sec_key<secondary_key_type>(sec_stack, sec_size);
+            } else {
+               char* heap = new char[sec_size];
+               ::kv_idx_key(_handle, 0, heap, sec_size, &sec_size);
+               _kr.sec_key = decode_sec_key<secondary_key_type>(heap, sec_size);
+               delete[] heap;
+            }
          }
       };
 
@@ -884,12 +992,13 @@ public:
       template<typename SecKey>
       const_iterator upper_bound(const SecKey& sec_key) const {
          auto sec = encode_sec_key(secondary_key_type(sec_key));
-         // Appending any byte makes the query strictly greater than the encoded
+         // Append a NUL byte to make the query strictly greater than the encoded
          // key under byte comparison, so kv_idx_lower_bound returns the first
          // entry past the target.  Works for both fixed-size BE keys (extra byte
          // extends length) and NUL-escape encoded strings (0x00 is the escape
          // sentinel, so the extended key cannot collide with a valid encoding).
-         sec.push_back('\0');
+         char nul = '\0';
+         sec.write(&nul, 1);
          int32_t handle = ::kv_idx_lower_bound(
             _tbl->code(), static_cast<uint64_t>(TableName), index_number,
             sec.data(), sec.size());
@@ -913,10 +1022,16 @@ public:
       void modify(name payer, const const_iterator& itr, const V& new_value) {
          sysio::check(itr._valid, "cannot modify end iterator");
          auto k = make_key(itr._row.key);
-         auto v = serialize_value(new_value);
          _tbl->update_secondaries(
             payer.value, itr._row.key, itr._row.value, new_value);
-         ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+         if constexpr (is_fixed_serializable_v<V>) {
+            char vbuf[sizeof(V)];
+            std::memcpy(vbuf, &new_value, sizeof(V));
+            ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         } else {
+            auto v = serialize_value(new_value);
+            ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+         }
       }
 
       void modify(const const_iterator& itr, const V& new_value) {

--- a/libraries/sysiolib/contracts/sysio/kv_it_handle.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_it_handle.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <cstdint>
+
+// RAII wrappers for KV iterator handles.
+// Non-template base — one code copy in WASM per destroy function.
+
+extern "C" {
+   __attribute__((sysio_wasm_import))
+   void kv_it_destroy(uint32_t handle);
+   __attribute__((sysio_wasm_import))
+   void kv_idx_destroy(uint32_t handle);
+}
+
+namespace sysio { namespace kv { namespace detail {
+
+template<void(*DestroyFn)(uint32_t)>
+struct kv_handle {
+   int32_t h = -1;
+   kv_handle() = default;
+   explicit kv_handle(int32_t v) : h(v) {}
+   explicit kv_handle(uint32_t v) : h(static_cast<int32_t>(v)) {}
+   ~kv_handle() { if (h >= 0) DestroyFn(static_cast<uint32_t>(h)); }
+   kv_handle(kv_handle&& o) noexcept : h(o.h) { o.h = -1; }
+   kv_handle& operator=(kv_handle&& o) noexcept {
+      if (this != &o) { reset(); h = o.h; o.h = -1; }
+      return *this;
+   }
+   kv_handle(const kv_handle&) = delete;
+   kv_handle& operator=(const kv_handle&) = delete;
+   void reset(int32_t v = -1) { if (h >= 0) DestroyFn(static_cast<uint32_t>(h)); h = v; }
+   void reset(uint32_t v) { reset(static_cast<int32_t>(v)); }
+   int32_t release() { int32_t v = h; h = -1; return v; }
+   operator int32_t() const { return h; }
+};
+
+using it_handle  = kv_handle<::kv_it_destroy>;
+using idx_handle = kv_handle<::kv_idx_destroy>;
+
+}}} // namespace sysio::kv::detail

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -140,7 +140,7 @@ namespace _kv_multi_index_detail {
    // Avoids heap allocation for small known-size secondary key encodings.
    template<size_t N>
    struct fixed_buf {
-      char data_[N];
+      char data_[N] = {};
       const char* data() const { return data_; }
       char* data() { return data_; }
       constexpr size_t size() const { return N; }

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -86,6 +86,8 @@ extern "C" {
 #include <iterator>
 
 #include <sysio/kv_constants.hpp>
+#include <sysio/kv_it_handle.hpp>
+#include <sysio/kv_raw_table.hpp>  // for sysio::kv::ser_buf
 
 namespace sysio {
 
@@ -114,6 +116,11 @@ inline constexpr name same_payer{};
 
 namespace _kv_multi_index_detail {
 
+   // Encoded sizes for big-endian KV key components.
+   static constexpr size_t enc_u64   = 8;   // one BE uint64_t
+   static constexpr size_t enc_u128  = 16;  // two BE uint64_t halves
+   static constexpr size_t enc_scope = 8;   // scope is one BE uint64_t
+
    inline void encode_be64(char* buf, uint64_t v) {
       for (int i = 7; i >= 0; --i) {
          buf[i] = static_cast<char>(v & 0xFF);
@@ -129,6 +136,18 @@ namespace _kv_multi_index_detail {
       return v;
    }
 
+   // Fixed-size buffer with vector-compatible .data()/.size() interface.
+   // Avoids heap allocation for small known-size secondary key encodings.
+   template<size_t N>
+   struct fixed_buf {
+      char data_[N];
+      const char* data() const { return data_; }
+      char* data() { return data_; }
+      constexpr size_t size() const { return N; }
+      friend bool operator==(const fixed_buf& a, const fixed_buf& b) { return memcmp(a.data_, b.data_, N) == 0; }
+      friend bool operator!=(const fixed_buf& a, const fixed_buf& b) { return !(a == b); }
+   };
+
    // Encode a secondary key to bytes for kv_idx_store
    template<typename T>
    inline std::vector<char> encode_secondary(const T& key) {
@@ -139,54 +158,44 @@ namespace _kv_multi_index_detail {
       return buf;
    }
 
-   // Encode uint64_t as 8-byte big-endian (for secondary index)
-   template<>
-   inline std::vector<char> encode_secondary(const uint64_t& key) {
-      std::vector<char> buf(8);
+   // Non-template overloads for fixed-size types — preferred over the template,
+   // return fixed_buf instead of vector to avoid heap allocation.
+
+   inline fixed_buf<enc_u64> encode_secondary(const uint64_t& key) {
+      fixed_buf<enc_u64> buf;
       encode_be64(buf.data(), key);
       return buf;
    }
 
-   // Encode uint128_t as 16-byte big-endian
-   template<>
-   inline std::vector<char> encode_secondary(const uint128_t& key) {
-      std::vector<char> buf(16);
+   inline fixed_buf<enc_u128> encode_secondary(const uint128_t& key) {
+      fixed_buf<enc_u128> buf;
       encode_be64(buf.data(), static_cast<uint64_t>(key >> 64));
-      encode_be64(buf.data() + 8, static_cast<uint64_t>(key));
+      encode_be64(buf.data() + enc_u64, static_cast<uint64_t>(key));
       return buf;
    }
 
-   // Encode double as sort-preserving 8 bytes
-   template<>
-   inline std::vector<char> encode_secondary(const double& key) {
+   inline fixed_buf<enc_u64> encode_secondary(const double& key) {
       uint64_t bits;
-      memcpy(&bits, &key, 8);
-      // IEEE 754 sign-magnitude → unsigned sortable
+      memcpy(&bits, &key, enc_u64);
       if (bits & (uint64_t(1) << 63))
-         bits = ~bits; // negative: flip all bits
+         bits = ~bits;
       else
-         bits ^= (uint64_t(1) << 63); // positive: flip sign bit only
-      std::vector<char> buf(8);
+         bits ^= (uint64_t(1) << 63);
+      fixed_buf<enc_u64> buf;
       encode_be64(buf.data(), bits);
       return buf;
    }
 
-   // Encode long double (128-bit softfloat in WASM) as sort-preserving 16 bytes.
-   // WASM stores long double as IEEE 754 binary128 in little-endian.
-   // Convert to big-endian and apply sign-magnitude → unsigned sortable transform.
-   template<>
-   inline std::vector<char> encode_secondary(const long double& key) {
-      char raw[16];
-      memcpy(raw, &key, 16);
-      // Convert little-endian to big-endian
-      std::vector<char> buf(16);
-      for (int i = 0; i < 16; ++i)
-         buf[i] = raw[15 - i];
-      // Sign-magnitude to unsigned sortable (sign bit is now buf[0] bit 7)
-      if (static_cast<uint8_t>(buf[0]) & 0x80u)
-         for (int i = 0; i < 16; ++i) buf[i] = ~buf[i]; // negative: flip all
+   inline fixed_buf<enc_u128> encode_secondary(const long double& key) {
+      char raw[enc_u128];
+      memcpy(raw, &key, enc_u128);
+      fixed_buf<enc_u128> buf;
+      for (int i = 0; i < static_cast<int>(enc_u128); ++i)
+         buf.data_[i] = raw[enc_u128 - 1 - i];
+      if (static_cast<uint8_t>(buf.data_[0]) & 0x80u)
+         for (int i = 0; i < static_cast<int>(enc_u128); ++i) buf.data_[i] = ~buf.data_[i];
       else
-         buf[0] = static_cast<char>(static_cast<uint8_t>(buf[0]) ^ 0x80u); // positive: flip sign
+         buf.data_[0] = static_cast<char>(static_cast<uint8_t>(buf.data_[0]) ^ 0x80u);
       return buf;
    }
 
@@ -236,10 +245,10 @@ class kv_multi_index {
       return p;
    }
 
-   // 8-byte primary key for secondary index: [pk:8B]
+   // Primary key for secondary index: [pk:8B]
    // Scope is encoded in the sec_key prefix instead (see store_all).
    struct pk_bytes_buf {
-      char data[8];
+      char data[_kv_multi_index_detail::enc_u64];
    };
 
    pk_bytes_buf pk_to_bytes(uint64_t pk) const {
@@ -249,16 +258,16 @@ class kv_multi_index {
    }
 
    // --- Row serialization (zero-copy for trivially_copyable types) ---
-   static std::vector<char> serialize_row(const T& obj) {
+   static sysio::kv::ser_buf serialize_row(const T& obj) {
       if constexpr (std::is_trivially_copyable<T>::value) {
          if (sizeof(T) == pack_size(obj)) {
-            std::vector<char> buf(sizeof(T));
+            sysio::kv::ser_buf buf(sizeof(T));
             memcpy(buf.data(), &obj, sizeof(T));
             return buf;
          }
       }
-      auto sz = pack_size(obj);
-      std::vector<char> buf(sz);
+      uint32_t sz = pack_size(obj);
+      sysio::kv::ser_buf buf(sz);
       datastream<char*> ds(buf.data(), buf.size());
       ds << obj;
       return buf;
@@ -282,13 +291,21 @@ class kv_multi_index {
       if (it != _items.end()) return it->second.get();
 
       auto key = make_pk(pk);
-      int32_t sz = ::kv_get(kv_format_standard, _code.value, key.data, 24, nullptr, 0);
+      char stack[sysio::kv::kv_value_stack_size];
+      int32_t sz = ::kv_get(kv_format_standard, _code.value, key.data, 24, stack, sysio::kv::kv_value_stack_size);
       if (sz < 0) return nullptr;
 
-      std::vector<char> buf(sz);
-      ::kv_get(kv_format_standard, _code.value, key.data, 24, buf.data(), buf.size());
+      T obj;
+      if (sz <= static_cast<int32_t>(sysio::kv::kv_value_stack_size)) {
+         obj = deserialize_row(stack, sz);
+      } else {
+         char* heap = new char[sz];
+         ::kv_get(kv_format_standard, _code.value, key.data, 24, heap, sz);
+         obj = deserialize_row(heap, sz);
+         delete[] heap;
+      }
 
-      auto ptr = std::make_unique<T>(deserialize_row(buf.data(), buf.size()));
+      auto ptr = std::make_unique<T>(std::move(obj));
       auto* raw = ptr.get();
       _items[pk] = std::move(ptr);
       return raw;
@@ -304,40 +321,40 @@ class kv_multi_index {
    template<typename SecVal>
    std::vector<char> encode_scoped_secondary(const SecVal& val) const {
       auto raw = _kv_multi_index_detail::encode_secondary(val);
-      std::vector<char> buf(8 + raw.size());
+      std::vector<char> buf(_kv_multi_index_detail::enc_scope + raw.size());
       _kv_multi_index_detail::encode_be64(buf.data(), _scope);
-      memcpy(buf.data() + 8, raw.data(), raw.size());
+      memcpy(buf.data() + _kv_multi_index_detail::enc_scope, raw.data(), raw.size());
       return buf;
    }
 
-   // Single-allocation fast path for uint64_t.
-   std::vector<char> encode_scoped_secondary(const uint64_t& val) const {
-      std::vector<char> buf(16);
+   // Stack fast path for uint64_t.
+   _kv_multi_index_detail::fixed_buf<_kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u64> encode_scoped_secondary(const uint64_t& val) const {
+      _kv_multi_index_detail::fixed_buf<_kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u64> buf;
       _kv_multi_index_detail::encode_be64(buf.data(), _scope);
-      _kv_multi_index_detail::encode_be64(buf.data() + 8, val);
+      _kv_multi_index_detail::encode_be64(buf.data() + _kv_multi_index_detail::enc_scope, val);
       return buf;
    }
 
-   // Single-allocation fast path for uint128_t.
-   std::vector<char> encode_scoped_secondary(const uint128_t& val) const {
-      std::vector<char> buf(24);
+   // Stack fast path for uint128_t.
+   _kv_multi_index_detail::fixed_buf<_kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u128> encode_scoped_secondary(const uint128_t& val) const {
+      _kv_multi_index_detail::fixed_buf<_kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u128> buf;
       _kv_multi_index_detail::encode_be64(buf.data(), _scope);
-      _kv_multi_index_detail::encode_be64(buf.data() + 8,  static_cast<uint64_t>(val >> 64));
-      _kv_multi_index_detail::encode_be64(buf.data() + 16, static_cast<uint64_t>(val));
+      _kv_multi_index_detail::encode_be64(buf.data() + _kv_multi_index_detail::enc_scope, static_cast<uint64_t>(val >> 64));
+      _kv_multi_index_detail::encode_be64(buf.data() + _kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u64, static_cast<uint64_t>(val));
       return buf;
    }
 
-   // Single-allocation fast path for double (sort-preserving transform + scope).
-   std::vector<char> encode_scoped_secondary(const double& val) const {
+   // Stack fast path for double (sort-preserving transform + scope).
+   _kv_multi_index_detail::fixed_buf<_kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u64> encode_scoped_secondary(const double& val) const {
       uint64_t bits;
-      memcpy(&bits, &val, 8);
+      memcpy(&bits, &val, _kv_multi_index_detail::enc_u64);
       if (bits & (uint64_t(1) << 63))
          bits = ~bits;
       else
          bits ^= (uint64_t(1) << 63);
-      std::vector<char> buf(16);
+      _kv_multi_index_detail::fixed_buf<_kv_multi_index_detail::enc_scope + _kv_multi_index_detail::enc_u64> buf;
       _kv_multi_index_detail::encode_be64(buf.data(), _scope);
-      _kv_multi_index_detail::encode_be64(buf.data() + 8, bits);
+      _kv_multi_index_detail::encode_be64(buf.data() + _kv_multi_index_detail::enc_scope, bits);
       return buf;
    }
 
@@ -350,7 +367,7 @@ class kv_multi_index {
          auto sec_key = idx.encode_scoped_secondary(ext(obj));
          auto pri_key = idx.pk_to_bytes(obj.primary_key());
          ::kv_idx_store(payer, static_cast<uint64_t>(TableName), N,
-                        pri_key.data, 8,
+                        pri_key.data, _kv_multi_index_detail::enc_u64,
                         sec_key.data(), sec_key.size());
          if constexpr (sizeof...(Rest) > 0) {
             secondary_ops<N+1, Rest...>::store_all(payer, idx, obj);
@@ -363,7 +380,7 @@ class kv_multi_index {
          auto sec_key = idx.encode_scoped_secondary(ext(obj));
          auto pri_key = idx.pk_to_bytes(obj.primary_key());
          ::kv_idx_remove(static_cast<uint64_t>(TableName), N,
-                         pri_key.data, 8,
+                         pri_key.data, _kv_multi_index_detail::enc_u64,
                          sec_key.data(), sec_key.size());
          if constexpr (sizeof...(Rest) > 0) {
             secondary_ops<N+1, Rest...>::remove_all(idx, obj);
@@ -378,7 +395,7 @@ class kv_multi_index {
          auto pri_key = idx.pk_to_bytes(old_obj.primary_key());
          if (old_sec != new_sec) {
             ::kv_idx_update(payer, static_cast<uint64_t>(TableName), N,
-                            pri_key.data, 8,
+                            pri_key.data, _kv_multi_index_detail::enc_u64,
                             old_sec.data(), old_sec.size(),
                             new_sec.data(), new_sec.size());
          }
@@ -427,7 +444,7 @@ public:
       using pointer = const T*;
       using reference = const T&;
 
-      const_iterator() : _idx(nullptr), _handle(-1), _valid(false) {}
+      const_iterator() : _idx(nullptr), _valid(false) {}
 
       const T& operator*() const {
          check(_valid && _obj, "dereferencing invalid iterator");
@@ -460,10 +477,10 @@ public:
 
       const_iterator& operator--() {
          check(_idx, "decrementing invalid iterator");
-         if (_handle == -1) {
+         if (_handle < 0) {
             // End iterator: create a real iterator and seek to last element
             auto prefix = _idx->make_prefix();
-            _handle = ::kv_it_create(kv_format_standard, _idx->_code.value, prefix.data, 16);
+            _handle.reset(::kv_it_create(kv_format_standard, _idx->_code.value, prefix.data, 16));
             // Seek past the end of this table's prefix range by using a max key
             char max_key[24];
             memcpy(max_key, prefix.data, 16);
@@ -500,25 +517,18 @@ public:
          return !(a == b);
       }
 
-      ~const_iterator() {
-         if (_handle != -1) ::kv_it_destroy(_handle);
-      }
-
       const_iterator(const_iterator&& o) noexcept
-         : _idx(o._idx), _handle(o._handle), _valid(o._valid), _obj(o._obj) {
-         o._handle = -1;
+         : _idx(o._idx), _handle(std::move(o._handle)), _valid(o._valid), _obj(o._obj) {
          o._valid = false;
          o._obj = nullptr;
       }
 
       const_iterator& operator=(const_iterator&& o) noexcept {
          if (this != &o) {
-            if (_handle != -1) ::kv_it_destroy(_handle);
             _idx = o._idx;
-            _handle = o._handle;
+            _handle = std::move(o._handle);
             _valid = o._valid;
             _obj = o._obj;
-            o._handle = -1;
             o._valid = false;
             o._obj = nullptr;
          }
@@ -527,33 +537,30 @@ public:
 
       // Copy (creates new iterator handle)
       const_iterator(const const_iterator& o) : _idx(o._idx), _valid(o._valid), _obj(o._obj) {
-         if (o._handle != -1 && _idx) {
+         if (o._handle >= 0 && _idx) {
             auto prefix = _idx->make_prefix();
-            _handle = ::kv_it_create(kv_format_standard, _idx->_code.value, prefix.data, 16);
+            _handle.reset(::kv_it_create(kv_format_standard, _idx->_code.value, prefix.data, 16));
             if (_valid && _obj) {
                auto key = _idx->make_pk(to_pk_uint64(_obj->primary_key()));
                ::kv_it_lower_bound(_handle, key.data, 24);
             }
-         } else {
-            _handle = -1;
          }
       }
 
       const_iterator& operator=(const const_iterator& o) {
          if (this != &o) {
-            if (_handle != -1) ::kv_it_destroy(_handle);
             _idx = o._idx;
             _valid = o._valid;
             _obj = o._obj;
-            if (o._handle != -1 && _idx) {
+            if (o._handle >= 0 && _idx) {
                auto prefix = _idx->make_prefix();
-               _handle = ::kv_it_create(kv_format_standard, _idx->_code.value, prefix.data, 16);
+               _handle.reset(::kv_it_create(kv_format_standard, _idx->_code.value, prefix.data, 16));
                if (_valid && _obj) {
                   auto key = _idx->make_pk(to_pk_uint64(_obj->primary_key()));
                   ::kv_it_lower_bound(_handle, key.data, 24);
                }
             } else {
-               _handle = -1;
+               _handle.reset();
             }
          }
          return *this;
@@ -562,7 +569,7 @@ public:
    private:
       friend class kv_multi_index;
       const kv_multi_index* _idx;
-      int32_t _handle;
+      kv::detail::it_handle _handle;
       bool _valid;
       const T* _obj;
 
@@ -615,8 +622,7 @@ public:
    const_iterator find(name primary) const { return find(primary.value); }
    const_iterator find(uint64_t primary) const {
       auto key = make_pk(primary);
-      int32_t sz = ::kv_get(kv_format_standard, _code.value, key.data, 24, nullptr, 0);
-      if (sz < 0) return end();
+      if (!::kv_contains(kv_format_standard, _code.value, key.data, 24)) return end();
 
       // Create iterator positioned at this key
       auto prefix = make_prefix();
@@ -832,10 +838,10 @@ public:
       // Helper: read primary key from secondary iterator handle.
       // The stored pri_key is [pk:8B].
       static bool read_primary_key(uint32_t handle, uint64_t& pk) {
-         char pri_buf[8];
+         char pri_buf[_kv_multi_index_detail::enc_u64];
          uint32_t actual = 0;
-         int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, 8, &actual);
-         if (status != 0 || actual != 8) return false;
+         int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, _kv_multi_index_detail::enc_u64, &actual);
+         if (status != 0 || actual != _kv_multi_index_detail::enc_u64) return false;
          pk = _kv_multi_index_detail::decode_be64(pri_buf);
          return true;
       }
@@ -871,12 +877,12 @@ public:
                // so lower_bound positions past this scope's entries, then prev
                // lands on the last entry in the scope.
                constexpr size_t sec_val_size = sizeof(secondary_key_type);
-               char max_sec[8 + sec_val_size];
+               char max_sec[_kv_multi_index_detail::enc_scope + sec_val_size];
                _kv_multi_index_detail::encode_be64(max_sec, _mi->_scope);
-               memset(max_sec + 8, 0xFF, sec_val_size);
-               _handle = ::kv_idx_lower_bound(
+               memset(max_sec + _kv_multi_index_detail::enc_scope, 0xFF, sec_val_size);
+               _handle.reset(::kv_idx_lower_bound(
                   _mi->_code.value, static_cast<uint64_t>(TableName), index_number,
-                  max_sec, sizeof(max_sec));
+                  max_sec, sizeof(max_sec)));
                if (_handle < 0) { _has_obj = false; }
                else if (::kv_idx_prev(_handle) == 0 && check_scope()) { _has_obj = true; load_current(); }
                else { _has_obj = false; }
@@ -893,15 +899,13 @@ public:
          }
          friend bool operator!=(const const_iterator& a, const const_iterator& b) { return !(a == b); }
 
-         ~const_iterator() { if (_handle >= 0) ::kv_idx_destroy(_handle); }
          const_iterator(const_iterator&& o) noexcept
-            : _mi(o._mi), _handle(o._handle), _has_obj(o._has_obj), _pk(o._pk), _obj(std::move(o._obj))
-            { o._handle = -1; o._has_obj = false; }
+            : _mi(o._mi), _handle(std::move(o._handle)), _has_obj(o._has_obj), _pk(o._pk), _obj(std::move(o._obj))
+            { o._has_obj = false; }
          const_iterator& operator=(const_iterator&& o) noexcept {
             if (this != &o) {
-               if (_handle >= 0) ::kv_idx_destroy(_handle);
-               _mi = o._mi; _handle = o._handle; _has_obj = o._has_obj; _pk = o._pk; _obj = std::move(o._obj);
-               o._handle = -1; o._has_obj = false;
+               _mi = o._mi; _handle = std::move(o._handle); _has_obj = o._has_obj; _pk = o._pk; _obj = std::move(o._obj);
+               o._has_obj = false;
             }
             return *this;
          }
@@ -910,7 +914,6 @@ public:
          }
          const_iterator& operator=(const const_iterator& o) {
             if (this != &o) {
-               if (_handle >= 0) ::kv_idx_destroy(_handle);
                _mi = o._mi; _has_obj = o._has_obj; _pk = o._pk; _obj = o._obj;
                _clone_handle(o);
             }
@@ -923,9 +926,9 @@ public:
                using extractor_t = typename std::tuple_element<index_number, std::tuple<typename Indices::secondary_extractor_type...>>::type;
                extractor_t ext;
                auto sec_bytes = _mi->encode_scoped_secondary(ext(_obj));
-               _handle = ::kv_idx_find_secondary(
+               _handle.reset(::kv_idx_find_secondary(
                   _mi->_code.value, static_cast<uint64_t>(TableName), index_number,
-                  sec_bytes.data(), sec_bytes.size());
+                  sec_bytes.data(), sec_bytes.size()));
                if (_handle < 0) return;
                // kv_idx_find_secondary lands on the first row with this
                // secondary key, but the source iterator may point to a later
@@ -938,13 +941,13 @@ public:
                      return;
                }
             } else {
-               _handle = -1;
+               _handle.reset();
             }
          }
 
          friend struct secondary_index_view;
          const kv_multi_index* _mi = nullptr;
-         int32_t _handle = -1;
+         kv::detail::idx_handle _handle;
          bool _has_obj = false;
          uint64_t _pk = 0;
          T _obj;
@@ -970,13 +973,13 @@ public:
          // another scope — treat that as end-of-range.
          bool check_scope() const {
             if (_handle < 0 || !_mi) return false;
-            char scope_buf[8];
+            char scope_buf[_kv_multi_index_detail::enc_scope];
             uint32_t actual = 0;
-            int32_t status = ::kv_idx_key(_handle, 0, scope_buf, 8, &actual);
-            if (status != 0 || actual < 8) return false;
-            char expected[8];
+            int32_t status = ::kv_idx_key(_handle, 0, scope_buf, _kv_multi_index_detail::enc_scope, &actual);
+            if (status != 0 || actual < _kv_multi_index_detail::enc_scope) return false;
+            char expected[_kv_multi_index_detail::enc_scope];
             _kv_multi_index_detail::encode_be64(expected, _mi->_scope);
-            return memcmp(scope_buf, expected, 8) == 0;
+            return memcmp(scope_buf, expected, _kv_multi_index_detail::enc_scope) == 0;
          }
       };
 
@@ -992,11 +995,11 @@ public:
 
       const_iterator begin() const {
          // Lower bound with scope prefix = first entry in this scope
-         char scope_prefix[8];
+         char scope_prefix[_kv_multi_index_detail::enc_scope];
          _kv_multi_index_detail::encode_be64(scope_prefix, _mi->_scope);
          int32_t handle = ::kv_idx_lower_bound(
             _mi->_code.value, static_cast<uint64_t>(TableName), index_number,
-            scope_prefix, 8);
+            scope_prefix, _kv_multi_index_detail::enc_scope);
          if (handle < 0) return end();
          // Verify we landed in the right scope (may be past it if scope is empty)
          const_iterator it(_mi, handle, true);

--- a/libraries/sysiolib/contracts/sysio/kv_raw_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_raw_table.hpp
@@ -59,7 +59,7 @@ struct key_buf {
       if (s <= inline_cap) {
          delete[] heap_; heap_ = nullptr;
          if (d && s) std::memcpy(inline_, d, s);
-      } else {
+      } else if (d && s) {
          if (!heap_ || len <= inline_cap || len < s) {
             delete[] heap_; heap_ = new char[s];
          }
@@ -113,6 +113,7 @@ struct ser_buf {
    ser_buf(ser_buf&& o) noexcept : size_(o.size_) {
       if (o.heap_) { heap_ = o.heap_; ptr_ = heap_; o.heap_ = nullptr; }
       else { std::memcpy(stack_, o.stack_, size_); ptr_ = stack_; }
+      o.ptr_ = o.stack_; o.size_ = 0;
    }
    ser_buf(const ser_buf&) = delete;
    ser_buf& operator=(const ser_buf&) = delete;
@@ -151,9 +152,13 @@ inline constexpr bool is_fixed_serializable_v = is_fixed_serializable<T>::value;
 // Works with SYSLIB_SERIALIZE-generated operators: `stream << key`
 // calls operator<< for each field, routing to BE encoding automatically.
 // ---------------------------------------------------------------------------
+#ifndef KV_KEY_BUF_CAP
+#define KV_KEY_BUF_CAP 256
+#endif
+
 class be_key_stream {
 public:
-   static constexpr uint32_t buf_cap = 128;
+   static constexpr uint32_t buf_cap = KV_KEY_BUF_CAP;
 private:
    char buf_[buf_cap];
    uint32_t size_ = 0;
@@ -169,9 +174,15 @@ private:
    }
 
    void write_escaped(const char* data, size_t len) {
+      // Upfront: data bytes + 2-byte terminator (no NUL escapes)
+      sysio::check(size_ + len + 2 <= buf_cap, "be_key_stream: key too large");
       for (size_t i = 0; i < len; ++i) {
          buf_[size_++] = data[i];
-         if (data[i] == '\0') buf_[size_++] = '\x01';
+         if (data[i] == '\0') {
+            // Each NUL adds 1 extra byte; still need room for remaining data + terminator
+            sysio::check(size_ + (len - i - 1) + 1 + 2 <= buf_cap, "be_key_stream: key too large");
+            buf_[size_++] = '\x01';
+         }
       }
       buf_[size_++] = '\0';
       buf_[size_++] = '\0';
@@ -179,6 +190,7 @@ private:
 
 public:
    void write(const char* data, size_t len) {
+      sysio::check(size_ + len <= buf_cap, "be_key_stream: key too large");
       if (len > 0) { std::memcpy(buf_ + size_, data, len); size_ += len; }
    }
 

--- a/libraries/sysiolib/contracts/sysio/kv_raw_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_raw_table.hpp
@@ -38,59 +38,156 @@ extern "C" {
 #include <utility>
 
 #include <sysio/kv_constants.hpp>
+#include <sysio/kv_it_handle.hpp>
 
 namespace sysio { namespace kv {
 
-/**
- * Big-endian key encoder for ordered KV storage.
- *
- * Writes each field in big-endian byte order so that memcmp-based key
- * comparison produces correct lexicographic ordering.
- *
- * Variable-length fields (string, vector<char>) use NUL-escape encoding:
- *   0x00 -> 0x00 0x01, terminated by 0x00 0x00
- * This preserves sort order for arbitrary byte sequences including embedded NULs.
- *
- * Works with SYSLIB_SERIALIZE-generated operators: `stream << key`
- * calls operator<< for each field, routing to BE encoding automatically.
- */
+// ---------------------------------------------------------------------------
+// key_buf — small-buffer key storage (64B inline, heap fallback for large keys)
+// ---------------------------------------------------------------------------
+struct key_buf {
+   static constexpr uint32_t inline_cap = 64;
+   char inline_[inline_cap];
+   char* heap_ = nullptr;
+   uint32_t len = 0;
+
+   const char* data() const { return (len > inline_cap) ? heap_ : inline_; }
+   uint32_t size() const { return len; }
+   bool empty() const { return len == 0; }
+
+   void assign(const char* d, uint32_t s) {
+      if (s <= inline_cap) {
+         delete[] heap_; heap_ = nullptr;
+         if (d && s) std::memcpy(inline_, d, s);
+      } else {
+         if (!heap_ || len <= inline_cap || len < s) {
+            delete[] heap_; heap_ = new char[s];
+         }
+         std::memcpy(heap_, d, s);
+      }
+      len = s;
+   }
+
+   void clear() { delete[] heap_; heap_ = nullptr; len = 0; }
+
+   bool equals(const char* d, uint32_t s) const {
+      return len == s && (len == 0 || std::memcmp(data(), d, len) == 0);
+   }
+
+   ~key_buf() { delete[] heap_; }
+   key_buf() = default;
+   key_buf(key_buf&& o) noexcept : len(o.len) {
+      if (o.len > inline_cap) { heap_ = o.heap_; o.heap_ = nullptr; }
+      else if (o.len) { std::memcpy(inline_, o.inline_, o.len); }
+      o.len = 0;
+   }
+   key_buf& operator=(key_buf&& o) noexcept {
+      if (this != &o) {
+         delete[] heap_; heap_ = nullptr;
+         len = o.len;
+         if (o.len > inline_cap) { heap_ = o.heap_; o.heap_ = nullptr; }
+         else if (o.len) { std::memcpy(inline_, o.inline_, o.len); }
+         o.len = 0;
+      }
+      return *this;
+   }
+   key_buf(const key_buf&) = delete;
+   key_buf& operator=(const key_buf&) = delete;
+
+   friend bool operator==(const key_buf& a, const key_buf& b) { return a.equals(b.data(), b.len); }
+   friend bool operator!=(const key_buf& a, const key_buf& b) { return !(a == b); }
+};
+
+// ---------------------------------------------------------------------------
+// ser_buf — stack-first serialization buffer (kv_value_stack_size inline, heap fallback)
+// ---------------------------------------------------------------------------
+struct ser_buf {
+   char stack_[kv_value_stack_size];
+   char* heap_ = nullptr;
+   char* ptr_;
+   uint32_t size_;
+   explicit ser_buf(uint32_t sz) : size_(sz) {
+      ptr_ = (sz <= kv_value_stack_size) ? stack_ : (heap_ = new char[sz]);
+   }
+   ~ser_buf() { delete[] heap_; }
+   ser_buf(ser_buf&& o) noexcept : size_(o.size_) {
+      if (o.heap_) { heap_ = o.heap_; ptr_ = heap_; o.heap_ = nullptr; }
+      else { std::memcpy(stack_, o.stack_, size_); ptr_ = stack_; }
+   }
+   ser_buf(const ser_buf&) = delete;
+   ser_buf& operator=(const ser_buf&) = delete;
+   ser_buf& operator=(ser_buf&&) = delete;
+   char* data() { return ptr_; }
+   const char* data() const { return ptr_; }
+   uint32_t size() const { return size_; }
+};
+
+// ---------------------------------------------------------------------------
+// Compile-time check: is T trivially copyable with sizeof == pack_size?
+// When true, serialization is just memcpy of sizeof(T) bytes — no dynamic sizing.
+// ---------------------------------------------------------------------------
+template<typename T, typename = void>
+struct is_fixed_serializable : std::false_type {};
+
+template<typename T>
+struct is_fixed_serializable<T, std::enable_if_t<
+   std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>
+   && (sizeof(T) == sysio::pack_size(T{}))
+>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_fixed_serializable_v = is_fixed_serializable<T>::value;
+
+// ---------------------------------------------------------------------------
+// be_key_stream — Big-endian key encoder (fixed buffer, no heap allocation)
+//
+// Writes each field in big-endian byte order so that memcmp-based key
+// comparison produces correct lexicographic ordering.
+//
+// Variable-length fields (string, vector<char>) use NUL-escape encoding:
+//   0x00 -> 0x00 0x01, terminated by 0x00 0x00
+// This preserves sort order for arbitrary byte sequences including embedded NULs.
+//
+// Works with SYSLIB_SERIALIZE-generated operators: `stream << key`
+// calls operator<< for each field, routing to BE encoding automatically.
+// ---------------------------------------------------------------------------
 class be_key_stream {
-   std::vector<char> buf_;
+public:
+   static constexpr uint32_t buf_cap = 128;
+private:
+   char buf_[buf_cap];
+   uint32_t size_ = 0;
 
    void write_be32(uint32_t v) {
-      size_t off = buf_.size();
-      buf_.resize(off + 4);
-      for (int i = 3; i >= 0; --i) { buf_[off + i] = static_cast<char>(v & 0xFF); v >>= 8; }
+      for (int i = 3; i >= 0; --i) { buf_[size_ + i] = static_cast<char>(v & 0xFF); v >>= 8; }
+      size_ += 4;
    }
 
    void write_be64(uint64_t v) {
-      size_t off = buf_.size();
-      buf_.resize(off + 8);
-      for (int i = 7; i >= 0; --i) { buf_[off + i] = static_cast<char>(v & 0xFF); v >>= 8; }
+      for (int i = 7; i >= 0; --i) { buf_[size_ + i] = static_cast<char>(v & 0xFF); v >>= 8; }
+      size_ += 8;
    }
 
-   // NUL-escape encoding: 0x00 -> 0x00,0x01 + 0x00,0x00 terminator.
-   // Preserves lexicographic ordering for arbitrary byte sequences.
    void write_escaped(const char* data, size_t len) {
       for (size_t i = 0; i < len; ++i) {
-         buf_.push_back(data[i]);
-         if (data[i] == '\0') buf_.push_back('\x01');
+         buf_[size_++] = data[i];
+         if (data[i] == '\0') buf_[size_++] = '\x01';
       }
-      buf_.push_back('\0');
-      buf_.push_back('\0');
+      buf_[size_++] = '\0';
+      buf_[size_++] = '\0';
    }
 
 public:
    void write(const char* data, size_t len) {
-      if (len > 0) buf_.insert(buf_.end(), data, data + len);
+      if (len > 0) { std::memcpy(buf_ + size_, data, len); size_ += len; }
    }
 
-   be_key_stream& operator<<(uint8_t v)  { buf_.push_back(static_cast<char>(v)); return *this; }
+   be_key_stream& operator<<(uint8_t v)  { buf_[size_++] = static_cast<char>(v); return *this; }
    be_key_stream& operator<<(int8_t v)   { return *this << static_cast<uint8_t>(static_cast<uint8_t>(v) ^ 0x80u); }
 
    be_key_stream& operator<<(uint16_t v) {
-      buf_.push_back(static_cast<char>((v >> 8) & 0xFF));
-      buf_.push_back(static_cast<char>(v & 0xFF));
+      buf_[size_++] = static_cast<char>((v >> 8) & 0xFF);
+      buf_[size_++] = static_cast<char>(v & 0xFF);
       return *this;
    }
    be_key_stream& operator<<(int16_t v) { return *this << static_cast<uint16_t>(static_cast<uint16_t>(v) ^ 0x8000u); }
@@ -135,7 +232,7 @@ public:
       return *this;
    }
 
-   be_key_stream& operator<<(bool v) { buf_.push_back(v ? 1 : 0); return *this; }
+   be_key_stream& operator<<(bool v) { buf_[size_++] = v ? 1 : 0; return *this; }
 
    be_key_stream& operator<<(const std::string& v) {
       write_escaped(v.data(), v.size());
@@ -147,9 +244,8 @@ public:
       return *this;
    }
 
-   std::vector<char> release() { return std::move(buf_); }
-   const char* data() const { return buf_.data(); }
-   size_t size() const { return buf_.size(); }
+   const char* data() const { return buf_; }
+   uint32_t size() const { return size_; }
 };
 
 /**
@@ -195,22 +291,22 @@ public:
  */
 template<typename K, typename V>
 class raw_table {
-   static std::vector<char> make_key(const K& key) {
+   static be_key_stream make_key(const K& key) {
       be_key_stream bs;
       bs << key;
-      return bs.release();
+      return bs;
    }
 
-   static std::vector<char> serialize_value(const V& value) {
+   static ser_buf serialize_value(const V& value) {
       if constexpr (std::is_trivially_copyable<V>::value) {
          if (sizeof(V) == sysio::pack_size(value)) {
-            std::vector<char> buf(sizeof(V));
+            ser_buf buf(sizeof(V));
             std::memcpy(buf.data(), &value, sizeof(V));
             return buf;
          }
       }
-      auto sz = sysio::pack_size(value);
-      std::vector<char> buf(sz);
+      uint32_t sz = sysio::pack_size(value);
+      ser_buf buf(sz);
       sysio::datastream<char*> ds(buf.data(), buf.size());
       ds << value;
       return buf;
@@ -241,21 +337,36 @@ public:
 
    int64_t set(const K& key, const V& value, sysio::name payer = sysio::name{}) {
       auto k = make_key(key);
-      auto v = serialize_value(value);
-      return ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+      if constexpr (is_fixed_serializable_v<V>) {
+         char vbuf[sizeof(V)];
+         std::memcpy(vbuf, &value, sizeof(V));
+         return ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+      } else {
+         auto v = serialize_value(value);
+         return ::kv_set(kv_format_raw, payer.value, k.data(), k.size(), v.data(), v.size());
+      }
    }
 
    std::optional<V> get(const K& key) const {
       auto k = make_key(key);
-      std::optional<V> result;
-
-      int32_t sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), nullptr, 0);
-      if (sz < 0) return result;
-
-      std::vector<char> buf(sz);
-      ::kv_get(kv_format_raw, code(), k.data(), k.size(), buf.data(), buf.size());
-      result.emplace(deserialize_value(buf.data(), buf.size()));
-      return result;
+      if constexpr (is_fixed_serializable_v<V>) {
+         char vbuf[sizeof(V)];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), vbuf, sizeof(V));
+         if (sz < 0) return {};
+         V val; std::memcpy(&val, vbuf, sizeof(V));
+         return val;
+      } else {
+         char stack[kv_value_stack_size];
+         int32_t sz = ::kv_get(kv_format_raw, code(), k.data(), k.size(), stack, kv_value_stack_size);
+         if (sz < 0) return {};
+         if (sz <= static_cast<int32_t>(kv_value_stack_size))
+            return deserialize_value(stack, sz);
+         char* heap = new char[sz];
+         ::kv_get(kv_format_raw, code(), k.data(), k.size(), heap, sz);
+         V val = deserialize_value(heap, sz);
+         delete[] heap;
+         return val;
+      }
    }
 
    bool contains(const K& key) const {
@@ -314,19 +425,16 @@ public:
       }
       friend bool operator!=(const const_iterator& a, const const_iterator& b) { return !(a == b); }
 
-      ~const_iterator() { if (_handle >= 0) ::kv_it_destroy(_handle); }
-
       const_iterator(const_iterator&& o) noexcept
-         : _tbl(o._tbl), _handle(o._handle), _valid(o._valid),
+         : _tbl(o._tbl), _handle(std::move(o._handle)), _valid(o._valid),
            _val(std::move(o._val)), _raw_key(std::move(o._raw_key))
-      { o._handle = -1; o._valid = false; }
+      { o._valid = false; }
 
       const_iterator& operator=(const_iterator&& o) noexcept {
          if (this != &o) {
-            if (_handle >= 0) ::kv_it_destroy(_handle);
-            _tbl = o._tbl; _handle = o._handle; _valid = o._valid;
+            _tbl = o._tbl; _handle = std::move(o._handle); _valid = o._valid;
             _val = std::move(o._val); _raw_key = std::move(o._raw_key);
-            o._handle = -1; o._valid = false;
+            o._valid = false;
          }
          return *this;
       }
@@ -336,10 +444,10 @@ public:
    private:
       friend class raw_table;
       const raw_table* _tbl = nullptr;
-      int32_t _handle = -1;
+      kv::detail::it_handle _handle;
       bool _valid = false;
       V _val;
-      std::vector<char> _raw_key;
+      key_buf _raw_key;
 
       const_iterator(const raw_table* t, int32_t h, bool valid)
          : _tbl(t), _handle(h), _valid(valid) {
@@ -348,26 +456,46 @@ public:
       static const_iterator make_end(const raw_table* m) { const_iterator it; it._tbl = m; return it; }
 
       void load() {
-         // Read key for equality comparison
+         // Read key (stack-buffer-first: 1 host call for keys <= 64B)
+         char key_stack[key_buf::inline_cap];
          uint32_t key_size = 0;
-         ::kv_it_key(_handle, 0, nullptr, 0, &key_size);
-         _raw_key.resize(key_size);
-         if (::kv_it_key(_handle, 0, _raw_key.data(), key_size, &key_size) != 0) {
+         if (::kv_it_key(_handle, 0, key_stack, key_buf::inline_cap, &key_size) != 0) {
             _valid = false; return;
          }
+         if (key_size <= key_buf::inline_cap) {
+            _raw_key.assign(key_stack, key_size);
+         } else {
+            char* kh = new char[key_size];
+            ::kv_it_key(_handle, 0, kh, key_size, &key_size);
+            _raw_key.assign(kh, key_size);
+            delete[] kh;
+         }
          // Read and deserialize value
-         uint32_t val_size = 0;
-         ::kv_it_value(_handle, 0, nullptr, 0, &val_size);
-         std::vector<char> vbuf(val_size);
-         ::kv_it_value(_handle, 0, vbuf.data(), val_size, &val_size);
-         _val = deserialize_value(vbuf.data(), vbuf.size());
+         if constexpr (is_fixed_serializable_v<V>) {
+            char vbuf[sizeof(V)];
+            uint32_t val_size = 0;
+            ::kv_it_value(_handle, 0, vbuf, sizeof(V), &val_size);
+            std::memcpy(&_val, vbuf, sizeof(V));
+         } else {
+            char val_stack[kv_value_stack_size];
+            uint32_t val_size = 0;
+            ::kv_it_value(_handle, 0, val_stack, kv_value_stack_size, &val_size);
+            if (val_size <= kv_value_stack_size) {
+               _val = deserialize_value(val_stack, val_size);
+            } else {
+               char* heap = new char[val_size];
+               ::kv_it_value(_handle, 0, heap, val_size, &val_size);
+               _val = deserialize_value(heap, val_size);
+               delete[] heap;
+            }
+         }
       }
 
       void ensure_handle() {
          if (_handle >= 0) return;
          if (!_tbl) return;
          // Empty prefix: iterate all format=0 entries in this contract
-         _handle = ::kv_it_create(kv_format_raw, _tbl->code(), nullptr, 0);
+         _handle.reset(::kv_it_create(kv_format_raw, _tbl->code(), nullptr, 0));
          if (_valid && !_raw_key.empty()) {
             ::kv_it_lower_bound(_handle, _raw_key.data(), _raw_key.size());
          }
@@ -393,7 +521,8 @@ public:
    /// First entry with key > given key.
    const_iterator upper_bound(const K& key) const {
       auto it = lower_bound(key);
-      if (it != end() && it._raw_key == make_key(key)) ++it;
+      auto encoded = make_key(key);
+      if (it != end() && it._raw_key.equals(encoded.data(), encoded.size())) ++it;
       return it;
    }
 };

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -9,6 +9,8 @@
  * SHiP compatible: keys can be reverse-mapped to legacy contract_row format.
  */
 
+#include <cstdint>
+
 // KV intrinsic declarations (primary only — kv::table does not use secondary indices)
 extern "C" {
    __attribute__((sysio_wasm_import))

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -38,6 +38,8 @@ extern "C" {
 }
 
 #include <sysio/kv_constants.hpp>
+#include <sysio/kv_it_handle.hpp>
+#include <sysio/kv_raw_table.hpp>  // for is_fixed_serializable_v, ser_buf
 
 #include <sysio/name.hpp>
 #include <sysio/serialize.hpp>
@@ -45,7 +47,6 @@ extern "C" {
 #include <sysio/check.hpp>
 #include <sysio/action.hpp>
 
-#include <memory>
 #include <cstring>
 #include <limits>
 #include <type_traits>
@@ -116,7 +117,6 @@ class table {
    static constexpr uint32_t key_size        = 24;
    static constexpr uint32_t prefix_size     = 16;
    static constexpr uint32_t tbl_prefix_size = 8;
-   static constexpr uint32_t stack_buf_size  = 256;
 
    uint64_t _code;
    uint64_t _scope;
@@ -141,17 +141,25 @@ class table {
       return p;
    }
 
-   // Common kv_get + deserialize. Stack-allocates for values <= stack_buf_size.
+   // Common kv_get + deserialize.
    bool get_value(const pk_buf& key, T& out) const {
-      char buf[stack_buf_size];
-      int32_t sz = ::kv_get(kv_format_standard, _code, key.data, key_size, buf, stack_buf_size);
-      if (sz < 0) return false;
-      if (static_cast<uint32_t>(sz) <= stack_buf_size) {
-         detail::load_value(out, buf, sz);
+      if constexpr (is_fixed_serializable_v<T>) {
+         char vbuf[sizeof(T)];
+         int32_t sz = ::kv_get(kv_format_standard, _code, key.data, key_size, vbuf, sizeof(T));
+         if (sz < 0) return false;
+         std::memcpy(&out, vbuf, sizeof(T));
       } else {
-         auto heap = std::make_unique<char[]>(sz);
-         ::kv_get(kv_format_standard, _code, key.data, key_size, heap.get(), sz);
-         detail::load_value(out, heap.get(), sz);
+         char buf[kv_value_stack_size];
+         int32_t sz = ::kv_get(kv_format_standard, _code, key.data, key_size, buf, kv_value_stack_size);
+         if (sz < 0) return false;
+         if (static_cast<uint32_t>(sz) <= kv_value_stack_size) {
+            detail::load_value(out, buf, sz);
+         } else {
+            char* heap = new char[sz];
+            ::kv_get(kv_format_standard, _code, key.data, key_size, heap, sz);
+            detail::load_value(out, heap, sz);
+            delete[] heap;
+         }
       }
       return true;
    }
@@ -170,15 +178,22 @@ class table {
 
    void store_row(uint64_t payer, uint64_t pk, const T& obj) const {
       auto key = make_pk(pk);
-      uint32_t sz = detail::value_size(obj);
-      if (sz <= stack_buf_size) {
-         char buf[stack_buf_size];
-         detail::store_value(obj, buf, stack_buf_size);
-         ::kv_set(kv_format_standard, payer, key.data, key_size, buf, sz);
+      if constexpr (is_fixed_serializable_v<T>) {
+         char vbuf[sizeof(T)];
+         std::memcpy(vbuf, &obj, sizeof(T));
+         ::kv_set(kv_format_standard, payer, key.data, key_size, vbuf, sizeof(T));
       } else {
-         auto heap = std::make_unique<char[]>(sz);
-         detail::store_value(obj, heap.get(), sz);
-         ::kv_set(kv_format_standard, payer, key.data, key_size, heap.get(), sz);
+         uint32_t sz = detail::value_size(obj);
+         if (sz <= kv_value_stack_size) {
+            char buf[kv_value_stack_size];
+            detail::store_value(obj, buf, kv_value_stack_size);
+            ::kv_set(kv_format_standard, payer, key.data, key_size, buf, sz);
+         } else {
+            char* heap = new char[sz];
+            detail::store_value(obj, heap, sz);
+            ::kv_set(kv_format_standard, payer, key.data, key_size, heap, sz);
+            delete[] heap;
+         }
       }
    }
 
@@ -224,15 +239,13 @@ public:
       }
       friend bool operator!=(const const_iterator& a, const const_iterator& b) { return !(a == b); }
 
-      ~const_iterator() { if (_handle >= 0) ::kv_it_destroy(_handle); }
       const_iterator(const_iterator&& o) noexcept
-         : _tbl(o._tbl), _handle(o._handle), _has_obj(o._has_obj), _obj(std::move(o._obj))
-         { o._handle = -1; o._has_obj = false; }
+         : _tbl(o._tbl), _handle(std::move(o._handle)), _has_obj(o._has_obj), _obj(std::move(o._obj))
+         { o._has_obj = false; }
       const_iterator& operator=(const_iterator&& o) noexcept {
          if (this != &o) {
-            if (_handle >= 0) ::kv_it_destroy(_handle);
-            _tbl = o._tbl; _handle = o._handle; _has_obj = o._has_obj; _obj = std::move(o._obj);
-            o._handle = -1; o._has_obj = false;
+            _tbl = o._tbl; _handle = std::move(o._handle); _has_obj = o._has_obj; _obj = std::move(o._obj);
+            o._has_obj = false;
          }
          return *this;
       }
@@ -242,7 +255,7 @@ public:
    private:
       friend class table;
       const table* _tbl = nullptr;
-      int32_t _handle = -1;
+      detail::it_handle _handle;
       bool _has_obj = false;
       T _obj;
 
@@ -262,7 +275,7 @@ public:
       void ensure_handle() {
          if (_handle >= 0) return;
          if (!_tbl) return;
-         _handle = ::kv_it_create(kv_format_standard, _tbl->_code, _tbl->_prefix.data, prefix_size);
+         _handle.reset(::kv_it_create(kv_format_standard, _tbl->_code, _tbl->_prefix.data, prefix_size));
          if (_has_obj) {
             auto key = _tbl->make_pk(_obj.primary_key());
             ::kv_it_lower_bound(_handle, key.data, key_size);
@@ -315,15 +328,13 @@ public:
       }
       friend bool operator!=(const scoped_iterator& a, const scoped_iterator& b) { return !(a == b); }
 
-      ~scoped_iterator() { if (_handle >= 0) ::kv_it_destroy(_handle); }
       scoped_iterator(scoped_iterator&& o) noexcept
-         : _tbl(o._tbl), _handle(o._handle), _has_obj(o._has_obj), _row(std::move(o._row))
-         { o._handle = -1; o._has_obj = false; }
+         : _tbl(o._tbl), _handle(std::move(o._handle)), _has_obj(o._has_obj), _row(std::move(o._row))
+         { o._has_obj = false; }
       scoped_iterator& operator=(scoped_iterator&& o) noexcept {
          if (this != &o) {
-            if (_handle >= 0) ::kv_it_destroy(_handle);
-            _tbl = o._tbl; _handle = o._handle; _has_obj = o._has_obj; _row = std::move(o._row);
-            o._handle = -1; o._has_obj = false;
+            _tbl = o._tbl; _handle = std::move(o._handle); _has_obj = o._has_obj; _row = std::move(o._row);
+            o._has_obj = false;
          }
          return *this;
       }
@@ -333,7 +344,7 @@ public:
    private:
       friend class table;
       const table* _tbl = nullptr;
-      int32_t _handle = -1;
+      detail::it_handle _handle;
       bool _has_obj = false;
       scoped_row _row;
 
@@ -444,19 +455,16 @@ public:
    }
 
    uint64_t available_primary_key() const {
-      uint32_t h = ::kv_it_create(kv_format_standard, _code, _prefix.data, prefix_size);
-      if (::kv_it_status(h) != 0) { ::kv_it_destroy(h); return 0; }
+      detail::it_handle h(::kv_it_create(kv_format_standard, _code, _prefix.data, prefix_size));
+      if (::kv_it_status(h) != 0) return 0;
       char max_key[key_size];
       detail::encode_be64(max_key,                static_cast<uint64_t>(TableName));
       detail::encode_be64(max_key + scope_offset, _scope);
       detail::encode_be64(max_key + pk_offset,    std::numeric_limits<uint64_t>::max());
-      // lower_bound with UINT64_MAX pk positions at iterator_end (past all entries).
-      // Return value only indicates exact-match; iterator is validly positioned either way.
       ::kv_it_lower_bound(h, max_key, key_size);
-      if (::kv_it_prev(h) != 0) { ::kv_it_destroy(h); return 0; }
+      if (::kv_it_prev(h) != 0) return 0;
       char key_buf[key_size]; uint32_t actual = 0;
       ::kv_it_key(h, 0, key_buf, key_size, &actual);
-      ::kv_it_destroy(h);
       if (actual != key_size) return 0;
       uint64_t last_pk = detail::decode_be64(key_buf + pk_offset);
       sysio::check(last_pk < std::numeric_limits<uint64_t>::max(),

--- a/libraries/sysiolib/core/sysio/serialize.hpp
+++ b/libraries/sysiolib/core/sysio/serialize.hpp
@@ -24,12 +24,12 @@
  */
 #define SYSLIB_SERIALIZE( TYPE,  MEMBERS ) \
  template<typename DataStream> \
- friend DataStream& operator << ( DataStream& ds, const TYPE& t ){ \
+ friend constexpr DataStream& operator << ( DataStream& ds, const TYPE& t ){ \
     uint32_t member_count = 0 BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_COUNT, +, MEMBERS ) ; \
     return member_count == 0 ? ds : (ds BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_OP, <<, MEMBERS ));\
  }\
  template<typename DataStream> \
- friend DataStream& operator >> ( DataStream& ds, TYPE& t ){ \
+ friend constexpr DataStream& operator >> ( DataStream& ds, TYPE& t ){ \
     uint32_t member_count = 0 BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_COUNT, +, MEMBERS ) ; \
     return member_count == 0 ? ds : (ds BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_OP, >>, MEMBERS ));\
  }
@@ -45,13 +45,13 @@
  */
 #define SYSLIB_SERIALIZE_DERIVED( TYPE, BASE, MEMBERS ) \
  template<typename DataStream> \
- friend DataStream& operator << ( DataStream& ds, const TYPE& t ){ \
+ friend constexpr DataStream& operator << ( DataStream& ds, const TYPE& t ){ \
     ds << static_cast<const BASE&>(t); \
     uint32_t member_count = 0 BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_COUNT, +, MEMBERS ); \
     return member_count == 0 ? ds : (ds BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_OP, <<, MEMBERS ));\
  }\
  template<typename DataStream> \
- friend DataStream& operator >> ( DataStream& ds, TYPE& t ){ \
+ friend constexpr DataStream& operator >> ( DataStream& ds, TYPE& t ){ \
     ds >> static_cast<BASE&>(t); \
     uint32_t member_count = 0 BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_COUNT, +, MEMBERS ); \
     return member_count == 0 ? ds : (ds BLUEGRASS_META_FOREACH_SEQ( SYSLIB_REFLECT_MEMBER_OP, >>, MEMBERS ));\
@@ -59,12 +59,12 @@
 
 #define SYSLIB_SERIALIZE_DERIVED_EMPTY( TYPE, BASE ) \
  template<typename DataStream> \
- friend DataStream& operator << ( DataStream& ds, const TYPE& t ){ \
+ friend constexpr DataStream& operator << ( DataStream& ds, const TYPE& t ){ \
     ds << static_cast<const BASE&>(t); \
     return ds;\
  }\
  template<typename DataStream> \
- friend DataStream& operator >> ( DataStream& ds, TYPE& t ){ \
+ friend constexpr DataStream& operator >> ( DataStream& ds, TYPE& t ){ \
     ds >> static_cast<BASE&>(t); \
     return ds;\
  }

--- a/plugins/sysio/abigen.hpp
+++ b/plugins/sysio/abigen.hpp
@@ -330,14 +330,20 @@ namespace sysio { namespace cdt {
          ctables.insert(t);
       }
 
-      void add_table( uint64_t name, const clang::CXXRecordDecl* decl, bool is_kv = false ) {
+      enum class kv_table_kind { legacy, kv_standard, kv_global };
+
+      void add_table( uint64_t name, const clang::CXXRecordDecl* decl, kv_table_kind kind = kv_table_kind::legacy ) {
          abi_table t;
          t.type = decl->getNameAsString();
          t.name = name_to_string(name);
-         if (is_kv) {
-            // KV tables use fixed 24-byte big-endian key: [table_name:8B][scope:8B][primary_key:8B]
+         if (kind == kv_table_kind::kv_standard) {
+            // Format=1: fixed 24-byte big-endian key: [table_name:8B][scope:8B][primary_key:8B]
             t.key_names = {"table_name", "scope", "primary_key"};
             t.key_types = {"name", "name", "uint64"};
+         } else if (kind == kv_table_kind::kv_global) {
+            // Format=0: single 8-byte big-endian name key
+            t.key_names = {"name"};
+            t.key_types = {"name"};
          }
          _abi.tables.insert(t);
       }
@@ -1068,14 +1074,19 @@ namespace sysio { namespace cdt {
          virtual bool VisitDecl(clang::Decl* decl) {
             if (const auto* d = dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
                if (d->getName() == "multi_index" || d->getName() == "singleton" ||
-                   d->getName() == "kv_multi_index" || d->getName() == "table") {
-                  bool is_kv = (d->getName() == "kv_multi_index" || d->getName() == "table");
+                   d->getName() == "kv_multi_index" || d->getName() == "table" ||
+                   d->getName() == "global") {
+                  abigen::kv_table_kind kind = abigen::kv_table_kind::legacy;
+                  if (d->getName() == "kv_multi_index" || d->getName() == "table")
+                     kind = abigen::kv_table_kind::kv_standard;
+                  else if (d->getName() == "global")
+                     kind = abigen::kv_table_kind::kv_global;
                   // second template parameter is table type
                   const auto* table_type = d->getTemplateArgs()[1].getAsType().getTypePtr()->getAsCXXRecordDecl();
                   auto table_decl = clang_wrapper::wrap_decl(table_type);
                   if ((table_decl.isSysioTable() && ag.is_sysio_contract(table_decl, ag.get_contract_name())) || defined_in_contract(d)) {
                      // first parameter is table name
-                     ag.add_table(d->getTemplateArgs()[0].getAsIntegral().getLimitedValue(), table_type, is_kv);
+                     ag.add_table(d->getTemplateArgs()[0].getAsIntegral().getLimitedValue(), table_type, kind);
                      if (table_decl.isSysioTable())
                         ag.add_struct(table_type);
                   }

--- a/tests/integration/contracts.hpp.in
+++ b/tests/integration/contracts.hpp.in
@@ -54,5 +54,8 @@ namespace sysio::testing {
 
       static std::vector<uint8_t> kv_singleton_tests_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../unit/test_contracts/kv_singleton_tests.wasm"); }
       static std::vector<char>    kv_singleton_tests_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/kv_singleton_tests.abi"); }
+
+      static std::vector<uint8_t> kv_global_tests_wasm() { return read_wasm("${CMAKE_BINARY_DIR}/../unit/test_contracts/kv_global_tests.wasm"); }
+      static std::vector<char>    kv_global_tests_abi() { return read_abi("${CMAKE_BINARY_DIR}/../unit/test_contracts/kv_global_tests.abi"); }
    };
 } //ns sysio::testing

--- a/tests/integration/kv_global_tests.cpp
+++ b/tests/integration/kv_global_tests.cpp
@@ -1,0 +1,58 @@
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#include <boost/test/unit_test.hpp>
+#pragma GCC diagnostic pop
+
+#include <sysio/testing/tester.hpp>
+
+#include <contracts.hpp>
+
+using namespace sysio;
+using namespace sysio::chain;
+using namespace sysio::testing;
+
+#ifdef NON_VALIDATING_TEST
+#define TESTER tester
+#else
+#define TESTER validating_tester
+#endif
+
+BOOST_AUTO_TEST_SUITE(kv_global_tests)
+
+BOOST_FIXTURE_TEST_CASE(kv_global_integration, TESTER) { try {
+   produce_blocks(1);
+   create_account( "kvglob"_n );
+   produce_blocks(1);
+   set_code( "kvglob"_n, contracts::kv_global_tests_wasm() );
+   set_abi( "kvglob"_n, contracts::kv_global_tests_abi().data() );
+   produce_blocks(1);
+
+   // POD (trivially-copyable) path
+   push_action( "kvglob"_n, "podsetget"_n,   "kvglob"_n, {} );
+   push_action( "kvglob"_n, "getdefault"_n,  "kvglob"_n, {} );
+   push_action( "kvglob"_n, "getorcreate"_n, "kvglob"_n, {} );
+   push_action( "kvglob"_n, "twonames"_n,    "kvglob"_n, {} );
+
+   // String (non-trivially-copyable) path
+   push_action( "kvglob"_n, "strsetget"_n,   "kvglob"_n, {} );
+   push_action( "kvglob"_n, "strdefault"_n,  "kvglob"_n, {} );
+
+   BOOST_REQUIRE_EQUAL( validate(), true );
+} FC_LOG_AND_RETHROW() }
+
+// Negative: get on unset should assert
+BOOST_FIXTURE_TEST_CASE(kv_global_getunset, TESTER) { try {
+   produce_blocks(1);
+   create_account( "kvglob2"_n );
+   produce_blocks(1);
+   set_code( "kvglob2"_n, contracts::kv_global_tests_wasm() );
+   set_abi( "kvglob2"_n, contracts::kv_global_tests_abi().data() );
+   produce_blocks(1);
+   BOOST_CHECK_EXCEPTION(
+      push_action( "kvglob2"_n, "getunset"_n, "kvglob2"_n, {} ),
+      sysio_assert_message_exception,
+      sysio_assert_message_is("global does not exist")
+   );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/integration/kv_raw_table_tests.cpp
+++ b/tests/integration/kv_raw_table_tests.cpp
@@ -53,6 +53,36 @@ KV_RAW_TABLE_TEST( "kvmapn"_n, crossread )
 KV_RAW_TABLE_TEST( "kvmapo"_n, zeroval )
 KV_RAW_TABLE_TEST( "kvmapp"_n, ramdelta )
 KV_RAW_TABLE_TEST( "kvmapq"_n, setpayer )
+KV_RAW_TABLE_TEST( "kvmapr"_n, keymaxfit )
+
+// Negative tests: key overflow
+BOOST_FIXTURE_TEST_CASE(kv_raw_table_keyoverflow, TESTER) { try {
+   produce_blocks(1);
+   create_account( "kvmaps"_n );
+   produce_blocks(1);
+   set_code( "kvmaps"_n, contracts::kv_raw_table_tests_wasm() );
+   set_abi( "kvmaps"_n, contracts::kv_raw_table_tests_abi().data() );
+   produce_blocks(1);
+   BOOST_CHECK_EXCEPTION(
+      push_action( "kvmaps"_n, "keyoverflow"_n, "kvmaps"_n, {} ),
+      sysio_assert_message_exception,
+      sysio_assert_message_is("be_key_stream: key too large")
+   );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE(kv_raw_table_keynulover, TESTER) { try {
+   produce_blocks(1);
+   create_account( "kvmapt"_n );
+   produce_blocks(1);
+   set_code( "kvmapt"_n, contracts::kv_raw_table_tests_wasm() );
+   set_abi( "kvmapt"_n, contracts::kv_raw_table_tests_abi().data() );
+   produce_blocks(1);
+   BOOST_CHECK_EXCEPTION(
+      push_action( "kvmapt"_n, "keynulover"_n, "kvmapt"_n, {} ),
+      sysio_assert_message_exception,
+      sysio_assert_message_is("be_key_stream: key too large")
+   );
+} FC_LOG_AND_RETHROW() }
 
 // Negative test: erase non-existent key should assert (T1/T7)
 BOOST_FIXTURE_TEST_CASE(kv_raw_table_erasebad, TESTER) { try {

--- a/tests/integration/kv_singleton_tests.cpp
+++ b/tests/integration/kv_singleton_tests.cpp
@@ -32,6 +32,7 @@ BOOST_FIXTURE_TEST_CASE(kv_singleton_integration, TESTER) { try {
    push_action( "kvsngl"_n, "removetest"_n,  "kvsngl"_n, {} );
    push_action( "kvsngl"_n, "settwice"_n,    "kvsngl"_n, {} );
    push_action( "kvsngl"_n, "scopetest"_n,   "kvsngl"_n, {} );
+   push_action( "kvsngl"_n, "podsingleton"_n,"kvsngl"_n, {} );  // trivially-copyable fast path
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }

--- a/tests/integration/kv_table_tests.cpp
+++ b/tests/integration/kv_table_tests.cpp
@@ -42,6 +42,7 @@ BOOST_FIXTURE_TEST_CASE(kv_table_integration, TESTER) { try {
    push_action( "kvtest"_n, "setmethod"_n,   "kvtest"_n, {} );
    push_action( "kvtest"_n, "modifyobj"_n,  "kvtest"_n, {} );
    push_action( "kvtest"_n, "endallscope"_n, "kvtest"_n, {} );
+   push_action( "kvtest"_n, "podcrud"_n,    "kvtest"_n, {} );  // trivially-copyable fast path
 
    BOOST_CHECK_EXCEPTION(
       push_action( "kvtest"_n, "reqfindfail"_n, "kvtest"_n, {} ),

--- a/tests/unit/test_contracts/CMakeLists.txt
+++ b/tests/unit/test_contracts/CMakeLists.txt
@@ -18,6 +18,7 @@ add_contract(kv_table_tests kv_table_tests kv_table_tests.cpp)
 add_contract(kv_raw_table_tests kv_raw_table_tests kv_raw_table_tests.cpp)
 add_contract(kv_indexed_table_tests kv_indexed_table_tests kv_indexed_table_tests.cpp)
 add_contract(kv_singleton_tests kv_singleton_tests kv_singleton_tests.cpp)
+add_contract(kv_global_tests kv_global_tests kv_global_tests.cpp)
 add_contract(capi_tests capi_tests capi/capi.c capi/action.c capi/chain.c capi/crypto.c capi/db.c capi/permission.c
                                    capi/print.c capi/privileged.c capi/system.c capi/transaction.c)
 

--- a/tests/unit/test_contracts/kv_global_tests.cpp
+++ b/tests/unit/test_contracts/kv_global_tests.cpp
@@ -1,0 +1,166 @@
+#include <sysio/sysio.hpp>
+#include <sysio/kv_global.hpp>
+
+using namespace sysio;
+
+class [[sysio::contract("kv_global_tests")]] kv_global_tests : public contract {
+public:
+   using contract::contract;
+
+   // ── Trivially-copyable value (exercises is_fixed_serializable fast path) ──
+
+   struct pod_cfg {
+      uint64_t rate;
+      uint32_t flags;
+      SYSLIB_SERIALIZE(pod_cfg, (rate)(flags))
+   };
+   using pod_global = kv::global<"podcfg"_n, pod_cfg>;
+
+   // ── Non-trivially-copyable value (string field, exercises datastream path) ──
+
+   struct str_cfg {
+      uint64_t    version;
+      std::string label;
+      SYSLIB_SERIALIZE(str_cfg, (version)(label))
+   };
+   using str_global = kv::global<"strcfg"_n, str_cfg>;
+
+   // ── POD: set / get / exists / remove ─────────────────────────────────────
+
+   [[sysio::action]]
+   void podsetget() {
+      pod_global g(get_self());
+
+      check(!g.exists(), "podsetget: should not exist initially");
+
+      g.set({42, 0xFF}, get_self());
+      check(g.exists(), "podsetget: should exist after set");
+
+      auto val = g.get();
+      check(val.rate == 42, "podsetget: rate");
+      check(val.flags == 0xFF, "podsetget: flags");
+
+      // Overwrite
+      g.set({99, 0x01}, get_self());
+      val = g.get();
+      check(val.rate == 99, "podsetget: overwrite rate");
+      check(val.flags == 0x01, "podsetget: overwrite flags");
+
+      // Remove
+      g.remove();
+      check(!g.exists(), "podsetget: should not exist after remove");
+
+      // Double remove is safe
+      g.remove();
+   }
+
+   // ── String: set / get / exists / remove ──────────────────────────────────
+
+   [[sysio::action]]
+   void strsetget() {
+      str_global g(get_self());
+
+      check(!g.exists(), "strsetget: should not exist");
+
+      g.set({1, "hello"}, get_self());
+      check(g.exists(), "strsetget: should exist");
+
+      auto val = g.get();
+      check(val.version == 1, "strsetget: version");
+      check(val.label == "hello", "strsetget: label");
+
+      // Overwrite with different-length string
+      g.set({2, "a much longer label value"}, get_self());
+      val = g.get();
+      check(val.version == 2, "strsetget: overwrite version");
+      check(val.label == "a much longer label value", "strsetget: overwrite label");
+
+      g.remove();
+      check(!g.exists(), "strsetget: removed");
+   }
+
+   // ── get_or_default ───────────────────────────────────────────────────────
+
+   [[sysio::action]]
+   void getdefault() {
+      pod_global g(get_self());
+
+      // Not set — should return default
+      auto val = g.get_or_default({7, 0});
+      check(val.rate == 7, "getdefault: default rate");
+
+      // After set — should return stored
+      g.set({100, 0}, get_self());
+      val = g.get_or_default({7, 0});
+      check(val.rate == 100, "getdefault: stored rate");
+
+      g.remove();
+   }
+
+   // ── get_or_create ────────────────────────────────────────────────────────
+
+   [[sysio::action]]
+   void getorcreate() {
+      // Use a different name to avoid collisions with other tests
+      kv::global<"goc"_n, pod_cfg> g(get_self());
+
+      // First call: creates
+      auto val = g.get_or_create(get_self(), {55, 0x10});
+      check(val.rate == 55, "getorcreate: created rate");
+
+      // Second call: returns existing
+      val = g.get_or_create(get_self(), {99, 0x20});
+      check(val.rate == 55, "getorcreate: existing rate unchanged");
+
+      g.remove();
+   }
+
+   // ── get on unset should assert ───────────────────────────────────────────
+
+   [[sysio::action]]
+   void getunset() {
+      kv::global<"empty"_n, pod_cfg> g(get_self());
+      g.get(); // should abort: "global does not exist"
+   }
+
+   // ── Two globals with different names are independent ─────────────────────
+
+   [[sysio::action]]
+   void twonames() {
+      kv::global<"cfg1"_n, pod_cfg> g1(get_self());
+      kv::global<"cfg2"_n, pod_cfg> g2(get_self());
+
+      g1.set({10, 1}, get_self());
+      g2.set({20, 2}, get_self());
+
+      check(g1.get().rate == 10, "twonames: g1 rate");
+      check(g2.get().rate == 20, "twonames: g2 rate");
+
+      // Remove one, other unaffected
+      g1.remove();
+      check(!g1.exists(), "twonames: g1 removed");
+      check(g2.exists(), "twonames: g2 still exists");
+      check(g2.get().rate == 20, "twonames: g2 still 20");
+
+      g2.remove();
+   }
+
+   // ── String get_or_default / get_or_create ────────────────────────────────
+
+   [[sysio::action]]
+   void strdefault() {
+      str_global g(get_self());
+
+      auto val = g.get_or_default({0, "fallback"});
+      check(val.label == "fallback", "strdefault: default label");
+
+      kv::global<"strgoc"_n, str_cfg> g2(get_self());
+      val = g2.get_or_create(get_self(), {1, "created"});
+      check(val.label == "created", "strdefault: created label");
+
+      val = g2.get_or_create(get_self(), {2, "other"});
+      check(val.label == "created", "strdefault: existing label");
+
+      g2.remove();
+   }
+};

--- a/tests/unit/test_contracts/kv_global_tests.cpp
+++ b/tests/unit/test_contracts/kv_global_tests.cpp
@@ -11,7 +11,7 @@ public:
 
    struct pod_cfg {
       uint64_t rate;
-      uint32_t flags;
+      uint64_t flags;
       SYSLIB_SERIALIZE(pod_cfg, (rate)(flags))
    };
    using pod_global = kv::global<"podcfg"_n, pod_cfg>;
@@ -164,3 +164,6 @@ public:
       g2.remove();
    }
 };
+
+static_assert(sysio::kv::is_fixed_serializable_v<kv_global_tests::pod_cfg>,
+              "pod_cfg must hit the zero-copy fast path");

--- a/tests/unit/test_contracts/kv_raw_table_tests.cpp
+++ b/tests/unit/test_contracts/kv_raw_table_tests.cpp
@@ -522,6 +522,45 @@ public:
       check(delta_erase < 0, "ramdelta: erase should return negative delta");
    }
 
+   // ── T6: be_key_stream boundary tests ──────────────────────────────────────
+   // Default KV_KEY_BUF_CAP is 256. Tests use that default.
+
+   struct longstr_key {
+      uint64_t tag;
+      std::string s;
+      SYSLIB_SERIALIZE(longstr_key, (tag)(s))
+   };
+
+   kv::raw_table<longstr_key, tiny_val> longstr_store;
+
+   [[sysio::action]]
+   void keymaxfit() {
+      // 8 (tag BE) + 246 (string chars) + 2 (NUL-escape terminator) = 256 = buf_cap exactly
+      std::string maxstr(246, 'x');
+      longstr_store.set({1, maxstr}, {1});
+      check(longstr_store.contains({1, maxstr}), "keymaxfit: should store max-fit key");
+      auto val = longstr_store.get({1, maxstr});
+      check(val.has_value(), "keymaxfit: should read back");
+   }
+
+   [[sysio::action]]
+   void keyoverflow() {
+      // 8 (tag BE) + 247 (string chars) + 2 (terminator) = 257 > 256 = overflow
+      std::string toostr(247, 'x');
+      longstr_store.set({1, toostr}, {1});
+      // Should abort with "be_key_stream: key too large" before reaching here
+      check(false, "keyoverflow: should have aborted");
+   }
+
+   [[sysio::action]]
+   void keynulover() {
+      // String with embedded NULs: each NUL adds 1 extra byte
+      // 8 (tag) + 230 chars (all NUL) + 230 NUL escapes + 2 terminator = 470 > 256
+      std::string nuls(230, '\0');
+      longstr_store.set({1, nuls}, {1});
+      check(false, "keynulover: should have aborted");
+   }
+
    // ── T6: set with explicit payer ──────────────────────────────────────────
 
    [[sysio::action]]

--- a/tests/unit/test_contracts/kv_singleton_tests.cpp
+++ b/tests/unit/test_contracts/kv_singleton_tests.cpp
@@ -105,6 +105,49 @@ public:
       cfg.get(); // should abort: "singleton does not exist"
    }
 
+   // ── Trivially-copyable singleton (exercises is_fixed_serializable fast path) ──
+
+   struct pod_config {
+      uint64_t rate;
+      uint32_t flags;
+      SYSLIB_SERIALIZE(pod_config, (rate)(flags))
+   };
+   using pod_singleton = singleton<"podcfg"_n, pod_config>;
+
+   [[sysio::action]]
+   void podsingleton() {
+      pod_singleton cfg(get_self(), get_self().value);
+
+      check(!cfg.exists(), "podsingleton: should not exist");
+
+      cfg.set({42, 0xFF}, get_self());
+      check(cfg.exists(), "podsingleton: should exist after set");
+
+      auto val = cfg.get();
+      check(val.rate == 42, "podsingleton: rate");
+      check(val.flags == 0xFF, "podsingleton: flags");
+
+      // Overwrite
+      cfg.set({99, 0x01}, get_self());
+      val = cfg.get();
+      check(val.rate == 99, "podsingleton: overwrite rate");
+
+      // get_or_default
+      pod_singleton cfg2(get_self(), "pod2"_n.value);
+      val = cfg2.get_or_default({7, 0});
+      check(val.rate == 7, "podsingleton: default rate");
+
+      // get_or_create
+      val = cfg2.get_or_create(get_self(), {8, 0});
+      check(val.rate == 8, "podsingleton: created rate");
+      val = cfg2.get_or_create(get_self(), {9, 0});
+      check(val.rate == 8, "podsingleton: existing rate");
+
+      // Remove
+      cfg.remove();
+      check(!cfg.exists(), "podsingleton: removed");
+   }
+
    [[sysio::action]]
    void scopetest() {
       config_singleton cfg1(get_self(), "scope1"_n.value);

--- a/tests/unit/test_contracts/kv_singleton_tests.cpp
+++ b/tests/unit/test_contracts/kv_singleton_tests.cpp
@@ -109,7 +109,7 @@ public:
 
    struct pod_config {
       uint64_t rate;
-      uint32_t flags;
+      uint64_t flags;  // uint64_t (not uint32_t) avoids trailing padding so sizeof==pack_size
       SYSLIB_SERIALIZE(pod_config, (rate)(flags))
    };
    using pod_singleton = singleton<"podcfg"_n, pod_config>;
@@ -166,3 +166,6 @@ public:
       check(cfg2.get().max_supply == 222, "scope2 value should be unchanged");
    }
 };
+
+static_assert(sysio::kv::is_fixed_serializable_v<kv_singleton_tests::pod_config>,
+              "pod_config must hit the zero-copy fast path");

--- a/tests/unit/test_contracts/kv_table_tests.cpp
+++ b/tests/unit/test_contracts/kv_table_tests.cpp
@@ -314,7 +314,7 @@ public:
    struct [[sysio::table]] pod_row {
       uint64_t id;
       uint64_t amount;
-      uint32_t flags;
+      uint64_t flags;  // uint64_t avoids trailing padding so sizeof==pack_size
 
       uint64_t primary_key() const { return id; }
       SYSLIB_SERIALIZE(pod_row, (id)(amount)(flags))
@@ -388,3 +388,7 @@ public:
       check(count >= 1, "endallscope: should find at least 1 row");
    }
 };
+
+// static_assert after class — friend operators visible via ADL at this point
+static_assert(sysio::kv::is_fixed_serializable_v<kv_table_tests::pod_row>,
+              "pod_row must hit the zero-copy fast path");

--- a/tests/unit/test_contracts/kv_table_tests.cpp
+++ b/tests/unit/test_contracts/kv_table_tests.cpp
@@ -309,6 +309,65 @@ public:
       t.modify(itr, get_self(), [](tbl_row& r) { r.id = 999; }); // should abort: cannot change pk
    }
 
+   // ── Trivially-copyable value type (exercises is_fixed_serializable fast path) ──
+
+   struct [[sysio::table]] pod_row {
+      uint64_t id;
+      uint64_t amount;
+      uint32_t flags;
+
+      uint64_t primary_key() const { return id; }
+      SYSLIB_SERIALIZE(pod_row, (id)(amount)(flags))
+   };
+   using pod_table = kv::table<"podtbl"_n, pod_row>;
+
+   [[sysio::action]]
+   void podcrud() {
+      pod_table t(get_self(), get_self().value);
+
+      // Emplace
+      t.emplace(get_self(), [](pod_row& r) { r.id = 1; r.amount = 1000; r.flags = 0x01; });
+      t.emplace(get_self(), [](pod_row& r) { r.id = 2; r.amount = 2000; r.flags = 0x02; });
+
+      // Get
+      auto row = t.get(1);
+      check(row.amount == 1000, "podcrud: get amount");
+      check(row.flags == 0x01, "podcrud: get flags");
+
+      // Find + dereference
+      auto it = t.find(2);
+      check(it != t.end(), "podcrud: find");
+      check(it->amount == 2000, "podcrud: find amount");
+
+      // Modify via iterator
+      t.modify(it, get_self(), [](pod_row& r) { r.amount = 9999; r.flags = 0xFF; });
+      auto updated = t.get(2);
+      check(updated.amount == 9999, "podcrud: modify amount");
+      check(updated.flags == 0xFF, "podcrud: modify flags");
+
+      // Iterate
+      uint32_t count = 0;
+      for (auto i = t.begin(); i != t.end(); ++i) ++count;
+      check(count == 2, "podcrud: iterate count");
+
+      // Lower/upper bound
+      auto lb = t.lower_bound(2);
+      check(lb != t.end() && lb->id == 2, "podcrud: lower_bound");
+      auto ub = t.upper_bound(1);
+      check(ub != t.end() && ub->id == 2, "podcrud: upper_bound");
+
+      // Contains
+      check(t.contains(1), "podcrud: contains");
+      check(!t.contains(999), "podcrud: !contains");
+
+      // Erase
+      t.erase(1);
+      check(!t.contains(1), "podcrud: erase");
+
+      // Available primary key
+      check(t.available_primary_key() == 3, "podcrud: available_pk");
+   }
+
    [[sysio::action]]
    void endallscope() {
       eas_table t(get_self(), 0);


### PR DESCRIPTION
## Summary

- RAII `kv_handle<DestroyFn>` template for iterator lifetime management
- `is_fixed_serializable_v<T>` compile-time trait for zero-copy memcpy serialization
- Stack-buffer-first patterns: `be_key_stream` (256B, user-configurable via `-DKV_KEY_BUF_CAP`), `key_buf` (64B inline + heap), `ser_buf` (256B inline + heap)
- `fixed_buf<N>` for kv_multi_index secondary key encoding (no heap)
- New `kv::global<Name, T>` abstraction — non-scoped singleton, format=0
- `constexpr` SYSLIB_SERIALIZE macros (enables compile-time `pack_size` for user structs)
- ABI generator: emit `key_names`/`key_types` for `kv::global` tables
- Bounds checking in `be_key_stream::write_escaped()` and `write()`
- Docs: zero-copy guide, static_assert placement, KV_KEY_BUF_CAP, migration guide, "Why Upgrade from multi_index"

## Performance

- Zero heap allocation for trivially-copyable types (compile-time `sizeof(T)` buffer)
- 1 host call per read/write (vs 2 for probe+read pattern)
- Iterator loads: 1-2 host calls (vs 4 for probe+read on key+value)
- `kv_multi_index` unchanged (backward-compatible cache preserved)

## Test plan

- [x] 22/22 CDT tests pass (unit + integration)
- [x] `static_assert(is_fixed_serializable_v<T>)` on all POD test structs
- [x] Boundary tests for `be_key_stream` overflow (max-fit, overflow, NUL-escape overflow)
- [x] Trivially-copyable + non-trivial coverage for kv::table, kv::singleton, kv::global
- [x] `test_multi_index.wasm` requires `wasm-opt -Oz --mvp-features` for net limit (527K > 524K)