### PR TITLE
kv: thread primary_id through secondary index intrinsics

### DIFF
--- a/docs/kv-intrinsics-reference.md
+++ b/docs/kv-intrinsics-reference.md
@@ -35,9 +35,41 @@ Read value by key. Returns actual value size, or -1 if not found.
 int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
 ```
 
-Erase a key-value pair. Returns the deleted primary row's chainbase id.
-Callers with secondary indexes should call `kv_erase` BEFORE `kv_idx_remove`
-and thread the returned id into each secondary removal.
+Erase a key-value pair. Returns the deleted primary row's chainbase id. The id
+is captured before the `kv_object` is removed, so it remains a valid lookup
+key for locating secondary rows that still reference the now-deleted primary.
+
+**Required call order for tables with secondary indexes:**
+
+1. `kv_erase(table_id, pk, pk_size)` → `primary_id`
+2. One `kv_idx_remove(sec_table_id, primary_id, sec_key, sec_key_size)` per
+   secondary index defined on the primary row.
+
+Secondary rows are keyed by `(code, sec_table_id, sec_key, primary_id)`; the
+contract cannot locate them until it learns `primary_id` from the erase return
+value. This is the inverse of the pre-`primary_id` convention (which removed
+secondaries first, then the primary) — pre-existing contracts that hand-call
+the raw intrinsics must be updated.
+
+The host does not cascade. Skipping step 2 leaves orphan `kv_index_object`
+rows that still reference `primary_id`. Consequences:
+
+- **RAM:** the sec row's RAM remains billed to its payer; `kv_erase` does not
+  refund it.
+- **Contract-side sec reads:** `kv_it_value` and `kv_idx_primary_key` on an
+  iterator pointing at the orphan return `iterator_erased` (see the Read /
+  iterator path table below) rather than aborting.
+- **RPC `get_table_rows`** secondary scans abort on the missing primary —
+  calls against the affected sec index fail loudly rather than silently
+  skipping rows.
+- **SHiP** serialization materializes `pri_key` from the primary and aborts
+  on the missing row; deltas for the affected table cannot be emitted.
+- **Recovery** is possible only if the contract (or an operator) can
+  determine the leaked `primary_id` out of band; the host does not export a
+  sec iterator's cached `primary_id`.
+
+The `kv_multi_index` and `kv_table` wrappers in this CDT enforce the order
+automatically; contracts built on the high-level APIs do not need to manage it.
 
 ### kv\_contains
 
@@ -89,9 +121,12 @@ void kv_idx_remove(uint32_t table_id, int64_t primary_id,
                    const void* sec_key, uint32_t sec_key_size);
 ```
 
-`primary_id` must match the id stored when the secondary row was inserted.
-Obtain it from the preceding `kv_erase` (erase primary first), or cache it
-from a prior `kv_set`.
+Remove a secondary index entry. `primary_id` must match the id stored when
+the secondary row was inserted; the composite `(code, table_id, sec_key,
+primary_id)` tuple must exist or the call aborts with `kv_key_not_found`.
+Obtain `primary_id` from the preceding `kv_erase` (erase primary first, per
+the [ordering requirement](#kv_erase)), or cache it from a prior `kv_set`.
+Call once per secondary index defined on the primary row.
 
 ### kv\_idx\_update
 

--- a/docs/kv-intrinsics-reference.md
+++ b/docs/kv-intrinsics-reference.md
@@ -12,7 +12,9 @@ int64_t kv_set(uint32_t table_id, uint64_t payer,
                const void* value, uint32_t value_size);
 ```
 
-Store a key-value pair. Returns RAM byte delta.
+Store or update a key-value pair. Returns the primary row's chainbase id.
+Thread the returned id into `kv_idx_store`/`kv_idx_update` so secondary rows
+reference the primary by id.
 
 - **table_id** — table namespace identifier (lower 16 bits of the DJB2 hash of table name)
 - **payer** — account to bill for RAM (0 = receiver)
@@ -33,7 +35,9 @@ Read value by key. Returns actual value size, or -1 if not found.
 int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
 ```
 
-Erase a key-value pair. Returns negative RAM delta.
+Erase a key-value pair. Returns the deleted primary row's chainbase id.
+Callers with secondary indexes should call `kv_erase` BEFORE `kv_idx_remove`
+and thread the returned id into each secondary removal.
 
 ### kv\_contains
 
@@ -70,26 +74,29 @@ int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_
 ### kv\_idx\_store
 
 ```c
-void kv_idx_store(uint64_t payer, uint32_t table_id,
-                  const void* pri_key, uint32_t pri_key_size,
+void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
                   const void* sec_key, uint32_t sec_key_size);
 ```
 
-Insert secondary index entry. `table_id` identifies the secondary index namespace.
+Insert a secondary index entry referencing a primary row by id. `table_id`
+identifies the secondary index namespace. `primary_id` is the chainbase id
+of the referenced primary row, returned by the preceding `kv_set`.
 
 ### kv\_idx\_remove
 
 ```c
-void kv_idx_remove(uint32_t table_id,
-                   const void* pri_key, uint32_t pri_key_size,
+void kv_idx_remove(uint32_t table_id, int64_t primary_id,
                    const void* sec_key, uint32_t sec_key_size);
 ```
+
+`primary_id` must match the id stored when the secondary row was inserted.
+Obtain it from the preceding `kv_erase` (erase primary first), or cache it
+from a prior `kv_set`.
 
 ### kv\_idx\_update
 
 ```c
-void kv_idx_update(uint64_t payer, uint32_t table_id,
-                   const void* pri_key, uint32_t pri_key_size,
+void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
                    const void* old_sec_key, uint32_t old_sec_key_size,
                    const void* new_sec_key, uint32_t new_sec_key_size);
 ```

--- a/docs/kv-intrinsics-reference.md
+++ b/docs/kv-intrinsics-reference.md
@@ -138,3 +138,43 @@ void    kv_idx_destroy(uint32_t handle);
 | Standard key size | 16B `[scope:8B BE][pk:8B BE]` — table name conveyed by `table_id`, not in key |
 | Table isolation | Each table and secondary index gets a unique `table_id` in the composite index |
 | Total intrinsics | 22 (5 primary ops + 7 primary iterator + 5 secondary ops + 5 secondary iterator) |
+
+## Error semantics
+
+The host validates every intrinsic call and is robust to any argument a WASM (CDT-built or not) can pass. The split between "aborts the action" and "returns a sentinel" is intentional.
+
+### Write path — aborts the action on bad input
+
+| Intrinsic | Scenario | Host behavior |
+|-----------|----------|---------------|
+| `kv_set` | new key | Create row. Returns chainbase id (stable across subsequent in-place updates) |
+| `kv_set` | existing key | Update in place via chainbase `modify`. **Returns the same id as the original insert** — secondary rows keyed by `primary_id` do not need to be rewritten |
+| `kv_set` | oversized key/value | Aborts with `kv_key_too_large` / `kv_value_too_large` |
+| `kv_set` / `kv_erase` | called in read-only transaction | Aborts with `table_operation_not_permitted` |
+| `kv_erase` | key not found | Aborts with `kv_key_not_found` |
+| `kv_idx_store` | `primary_id < 0` | Aborts with `kv_key_not_found` |
+| `kv_idx_store` | `primary_id` references non-existent row | Aborts with `kv_key_not_found` |
+| `kv_idx_store` | referenced primary owned by a different `code` | Aborts with `table_operation_not_permitted` (cross-contract protection) |
+| `kv_idx_remove` | `(sec_key, primary_id)` tuple not present | Aborts with `kv_key_not_found` |
+| `kv_idx_update` | old `(sec_key, primary_id)` tuple not present | Aborts with `kv_key_not_found` |
+
+### Read / iterator path — returns sentinel, never aborts
+
+| Intrinsic | Scenario | Host behavior |
+|-----------|----------|---------------|
+| `kv_get` | key not found | Returns `-1` |
+| `kv_contains` | key not found | Returns `0` |
+| `kv_idx_find_secondary` | not found | Returns `-1` |
+| `kv_idx_lower_bound` | table empty | Returns `-1` |
+| `kv_it_value` | slot not `iterator_ok` | Writes `actual_size = 0`, returns slot status |
+| `kv_it_value` | secondary handle whose referenced primary has been deleted | Sets slot to `iterator_erased`, writes `actual_size = 0`, returns `iterator_erased` |
+| `kv_idx_primary_key` | orphan secondary (primary deleted) | Sets slot to `iterator_erased`, writes `actual_size = 0`, returns `iterator_erased` |
+| `kv_it_*` / `kv_idx_*` | invalid / freed handle | Aborts with `kv_invalid_iterator` (handle validation is unconditional) |
+| `kv_idx_primary_key` | called with a primary-iterator handle | Aborts with `kv_invalid_iterator` |
+
+### Iterator handle rules
+
+- Handles are pool indices; every handle-accepting intrinsic validates `handle < pool_size && in_use` and aborts with `kv_invalid_iterator` if either fails.
+- Primary vs secondary handles are distinct: passing a primary handle to a `kv_idx_*` intrinsic (or vice versa) aborts with `kv_invalid_iterator`.
+- Exceeding the per-context iterator limit in `kv_it_create` / `kv_idx_find_secondary` / `kv_idx_lower_bound` aborts with `kv_iterator_limit_exceeded`.
+- Chainbase ids are monotonic within a session and preserved across snapshot save/load (via `emplace_with_id`), so `primary_id` references cached in an iterator slot remain valid for as long as the referenced primary row exists.

--- a/docs/kv-multi-index.md
+++ b/docs/kv-multi-index.md
@@ -34,6 +34,14 @@ The table name is conveyed by `table_id`, not embedded in the key.
 - `payer` parameter honored for RAM billing
 - `rbegin/rend`, `cbegin/cend` support
 
+## Secondary Index Storage and Ordering
+
+Secondary rows store an 8-byte `primary_id` (the referenced primary row's chainbase id), not a copy of the primary-key bytes. Iteration resolves the primary lazily via a by_id lookup, and `kv_idx_primary_key` materializes the primary-key bytes on demand.
+
+Within duplicate secondary keys, iteration order is **chainbase insertion order** (the order rows were inserted) rather than primary-key byte-lex order. Do not rely on a specific ordering for rows whose secondary keys collide; if you need deterministic per-key ordering, sort in the contract after collecting matches.
+
+This is baseline behavior at launch. Wire has no pre-existing `kv_multi_index` chain state, so no protocol feature gate or migration is involved.
+
 ## Singleton
 
 ```cpp

--- a/docs/kv-scoped-table.md
+++ b/docs/kv-scoped-table.md
@@ -39,7 +39,7 @@ kv::scoped_table<"accounts"_n, K, V> tbl("sysio.token"_n, owner.value);
 
 Primary keys are `[scope:8B BE][K encoded]` — byte-identical to `multi_index`'s `[scope:8B BE][pk:8B BE]` when `K` is a single `uint64_t`.
 
-Secondary keys are `[scope:8B BE][secondary_value encoded]`. Secondary rows reference the primary row by its chainbase id (8 bytes), not by a copy of the primary key bytes — iterator operations resolve the primary via an O(1) by_id lookup, and primary-key bytes are materialized lazily only when the contract reads them via `kv_idx_primary_key`.
+Secondary keys are `[scope:8B BE][secondary_value encoded]`. Secondary rows reference the primary row by its chainbase id (8 bytes), not by a copy of the primary key bytes — iterator operations resolve the primary via a by_id lookup, and primary-key bytes are materialized lazily only when the contract reads them via `kv_idx_primary_key`.
 
 ## API
 

--- a/docs/kv-scoped-table.md
+++ b/docs/kv-scoped-table.md
@@ -39,7 +39,7 @@ kv::scoped_table<"accounts"_n, K, V> tbl("sysio.token"_n, owner.value);
 
 Primary keys are `[scope:8B BE][K encoded]` — byte-identical to `multi_index`'s `[scope:8B BE][pk:8B BE]` when `K` is a single `uint64_t`.
 
-Secondary keys are `[scope:8B BE][secondary_value encoded]`. Secondary index pri_key stores only `[K encoded]` (no scope) — saves 8 bytes per secondary row.
+Secondary keys are `[scope:8B BE][secondary_value encoded]`. Secondary rows reference the primary row by its chainbase id (8 bytes), not by a copy of the primary key bytes — iterator operations resolve the primary via an O(1) by_id lookup, and primary-key bytes are materialized lazily only when the contract reads them via `kv_idx_primary_key`.
 
 ## API
 

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -855,23 +855,20 @@ int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_
    return intrinsics::get().call<intrinsics::kv_it_value>(handle, offset, dest, dest_size, actual_size);
 }
 
-void kv_idx_store(uint64_t payer, uint32_t table_id,
-                  const void* pri_key, uint32_t pri_key_size,
+void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
                   const void* sec_key, uint32_t sec_key_size) {
-   intrinsics::get().call<intrinsics::kv_idx_store>(payer, table_id, pri_key, pri_key_size, sec_key, sec_key_size);
+   intrinsics::get().call<intrinsics::kv_idx_store>(payer, table_id, primary_id, sec_key, sec_key_size);
 }
 
-void kv_idx_remove(uint32_t table_id,
-                   const void* pri_key, uint32_t pri_key_size,
+void kv_idx_remove(uint32_t table_id, int64_t primary_id,
                    const void* sec_key, uint32_t sec_key_size) {
-   intrinsics::get().call<intrinsics::kv_idx_remove>(table_id, pri_key, pri_key_size, sec_key, sec_key_size);
+   intrinsics::get().call<intrinsics::kv_idx_remove>(table_id, primary_id, sec_key, sec_key_size);
 }
 
-void kv_idx_update(uint64_t payer, uint32_t table_id,
-                   const void* pri_key, uint32_t pri_key_size,
+void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
                    const void* old_sec_key, uint32_t old_sec_key_size,
                    const void* new_sec_key, uint32_t new_sec_key_size) {
-   intrinsics::get().call<intrinsics::kv_idx_update>(payer, table_id, pri_key, pri_key_size, old_sec_key, old_sec_key_size, new_sec_key, new_sec_key_size);
+   intrinsics::get().call<intrinsics::kv_idx_update>(payer, table_id, primary_id, old_sec_key, old_sec_key_size, new_sec_key, new_sec_key_size);
 }
 
 int32_t kv_idx_find_secondary(capi_name code, uint32_t table_id,

--- a/libraries/sysiolib/capi/sysio/kv.h
+++ b/libraries/sysiolib/capi/sysio/kv.h
@@ -27,7 +27,9 @@ extern "C" {
  * @param key_size - length of key in bytes (max 256)
  * @param value - pointer to value bytes
  * @param value_size - length of value in bytes (max 256 KiB)
- * @return RAM byte delta (positive for growth, 0 for same-size update)
+ * @return chainbase id of the primary row. Thread this value into
+ *   kv_idx_store/kv_idx_update so secondary rows reference the primary
+ *   by id rather than by key bytes.
  */
 __attribute__((sysio_wasm_import))
 int64_t kv_set(uint32_t table_id, uint64_t payer, const void* key, uint32_t key_size, const void* value, uint32_t value_size);
@@ -52,7 +54,9 @@ int32_t kv_get(uint32_t table_id, capi_name code, const void* key, uint32_t key_
  * @param table_id - table identifier dispatching to the correct backing store
  * @param key - pointer to key bytes
  * @param key_size - length of key
- * @return negative RAM byte delta
+ * @return chainbase id of the deleted primary row. Callers with secondary
+ *   indexes should call kv_erase BEFORE kv_idx_remove and thread the
+ *   returned id into each secondary removal.
  */
 __attribute__((sysio_wasm_import))
 int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
@@ -152,33 +156,35 @@ int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_
 // --- Secondary KV Index ---
 
 /**
- * Store a secondary index entry.
+ * Store a secondary index entry referencing a primary row by id.
  * @param payer - account paying for RAM (0 = contract itself)
- * @param table_id - table identifier (encodes table name + index id)
- * @param pri_key - primary key bytes
- * @param pri_key_size - primary key size (max 256)
+ * @param table_id - secondary index identifier (encodes table name + index id)
+ * @param primary_id - chainbase id of the primary kv row (returned by kv_set)
  * @param sec_key - secondary key bytes
  * @param sec_key_size - secondary key size (max 256)
  */
 __attribute__((sysio_wasm_import))
-void kv_idx_store(uint64_t payer, uint32_t table_id,
-                  const void* pri_key, uint32_t pri_key_size,
+void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
                   const void* sec_key, uint32_t sec_key_size);
 
 /**
  * Remove a secondary index entry.
+ *
+ * @param table_id - secondary index identifier
+ * @param primary_id - chainbase id of the referenced primary row (obtain via
+ *   kv_erase before deleting the primary, or cache from a prior kv_set)
+ * @param sec_key - secondary key bytes
+ * @param sec_key_size - secondary key size
  */
 __attribute__((sysio_wasm_import))
-void kv_idx_remove(uint32_t table_id,
-                   const void* pri_key, uint32_t pri_key_size,
+void kv_idx_remove(uint32_t table_id, int64_t primary_id,
                    const void* sec_key, uint32_t sec_key_size);
 
 /**
- * Update a secondary index entry (change secondary key, keep primary key).
+ * Update a secondary index entry (change secondary key, keep primary_id).
  */
 __attribute__((sysio_wasm_import))
-void kv_idx_update(uint64_t payer, uint32_t table_id,
-                   const void* pri_key, uint32_t pri_key_size,
+void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
                    const void* old_sec_key, uint32_t old_sec_key_size,
                    const void* new_sec_key, uint32_t new_sec_key_size);
 

--- a/libraries/sysiolib/contracts/sysio/detail/kv_idx_intrinsics.hpp
+++ b/libraries/sysiolib/contracts/sysio/detail/kv_idx_intrinsics.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+// Secondary-index host intrinsics shared by kv_multi_index.hpp and
+// kv_table.hpp. Consolidated here so signature changes only need to
+// touch one place; both wrappers transitively reach these through
+// their own includes.
+//
+// Primary KV and primary-iterator intrinsics (kv_set/kv_get/kv_erase/
+// kv_contains, kv_it_*) are declared in <sysio/kv_utils.hpp>.
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+
+__attribute__((sysio_wasm_import))
+void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
+                  const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+void kv_idx_remove(uint32_t table_id, int64_t primary_id,
+                   const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
+                   const void* old_sec_key, uint32_t old_sec_key_size,
+                   const void* new_sec_key, uint32_t new_sec_key_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_find_secondary(uint64_t code, uint32_t table_id,
+                              const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_lower_bound(uint64_t code, uint32_t table_id,
+                           const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_next(uint32_t handle);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_prev(uint32_t handle);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_key(uint32_t handle, uint32_t offset,
+                   void* dest, uint32_t dest_size, uint32_t* actual_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_primary_key(uint32_t handle, uint32_t offset,
+                           void* dest, uint32_t dest_size, uint32_t* actual_size);
+
+__attribute__((sysio_wasm_import))
+void kv_idx_destroy(uint32_t handle);
+
+}

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -770,22 +770,19 @@ public:
       // Helper: read primary key from secondary iterator handle.
       // kv_idx_primary_key returns the full kv_object key bytes — for
       // kv_multi_index the primary row's key is [scope:8B][pk:8B] (16 bytes).
-      // kv_multi_index writes both the sec row and its referenced primary in
-      // the same scope, so any sec handle reachable from a given view must
-      // resolve to a primary in that view's scope. The caller passes the
-      // expected scope and we check() that the decoded scope matches before
-      // returning the pk portion — a cross-scope resolution is a host or
-      // wrapper bug, not a normal end-of-range condition.
+      // Returns false on read error or scope mismatch. Iterator advancement
+      // (kv_idx_lower_bound landing past the scope, kv_idx_next walking off
+      // the duplicate group) can legitimately land us on a primary in a
+      // different scope; callers treat that as end-of-range.
       static bool read_primary_key(uint32_t handle, uint64_t expected_scope, uint64_t& pk) {
          constexpr uint32_t full_size = _kv_multi_index_detail::scope_size
                                       + _kv_multi_index_detail::u64_size;
          char pri_buf[full_size];
-         uint32_t actual = 0;
-         int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, full_size, &actual);
-         if (status != 0 || actual != full_size) return false;
-         const uint64_t got_scope = _kv_multi_index_detail::decode_be64(pri_buf);
-         check(got_scope == expected_scope,
-               "kv_multi_index: secondary handle resolved to primary in a different scope");
+         uint32_t actual_size = 0;
+         int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, full_size, &actual_size);
+         if (status != 0 || actual_size != full_size) return false;
+         const uint64_t actual_scope = _kv_multi_index_detail::decode_be64(pri_buf);
+         if (actual_scope != expected_scope) return false;
          pk = _kv_multi_index_detail::decode_be64(pri_buf + _kv_multi_index_detail::scope_size);
          return true;
       }
@@ -877,6 +874,8 @@ public:
                // kv_idx_find_secondary lands on the first row with this
                // secondary key, but the source iterator may point to a later
                // duplicate. Advance until we find the matching primary key.
+               // read_primary_key returns false once we've walked past the
+               // duplicate group (different scope), ending the search.
                uint64_t found_pk = 0;
                if (read_primary_key(_handle, _mi->_scope, found_pk) && found_pk == _pk)
                   return;
@@ -918,9 +917,9 @@ public:
          bool check_scope() const {
             if (_handle < 0 || !_mi) return false;
             char scope_buf[_kv_multi_index_detail::scope_size];
-            uint32_t actual = 0;
-            int32_t status = ::kv_idx_key(_handle, 0, scope_buf, _kv_multi_index_detail::scope_size, &actual);
-            if (status != 0 || actual < _kv_multi_index_detail::scope_size) return false;
+            uint32_t actual_size = 0;
+            int32_t status = ::kv_idx_key(_handle, 0, scope_buf, _kv_multi_index_detail::scope_size, &actual_size);
+            if (status != 0 || actual_size < _kv_multi_index_detail::scope_size) return false;
             char expected[_kv_multi_index_detail::scope_size];
             _kv_multi_index_detail::encode_be64(expected, _mi->_scope);
             return memcmp(scope_buf, expected, _kv_multi_index_detail::scope_size) == 0;
@@ -938,17 +937,16 @@ public:
       const_reverse_iterator crend() const { return rend(); }
 
       const_iterator begin() const {
-         // Lower bound with scope prefix = first entry in this scope
+         // Lower bound with scope prefix = first entry in this scope.
+         // The iterator constructor verifies scope before loading, so an
+         // out-of-scope landing produces an end-equivalent iterator.
          char scope_prefix[_kv_multi_index_detail::scope_size];
          _kv_multi_index_detail::encode_be64(scope_prefix, _mi->_scope);
          int32_t handle = ::kv_idx_lower_bound(
             _mi->_code.value, _sec_table_id,
             scope_prefix, _kv_multi_index_detail::scope_size);
          if (handle < 0) return end();
-         // Verify we landed in the right scope (may be past it if scope is empty)
-         const_iterator it(_mi, handle, true);
-         if (it._has_obj && !it.check_scope()) return end();
-         return it;
+         return const_iterator(_mi, handle, true);
       }
 
       template<typename SecKey>
@@ -968,9 +966,7 @@ public:
             _mi->_code.value, _sec_table_id,
             sec_bytes.data(), sec_bytes.size());
          if (handle < 0) return end();
-         const_iterator it(_mi, handle, true);
-         if (it._has_obj && !it.check_scope()) return end();
-         return it;
+         return const_iterator(_mi, handle, true);
       }
 
       template<typename SecKey>

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -14,60 +14,16 @@
  */
 
 #include <cstdint>
-#include <sysio/kv_utils.hpp>
+#include <sysio/kv_utils.hpp>                   // primary KV + iterator intrinsics
+#include <sysio/detail/kv_idx_intrinsics.hpp>   // secondary-index intrinsics
 
-// KV intrinsic declarations (primary + secondary — multi_index uses both)
+// kv_get is used for the primary-row-cache load path but is not declared in
+// kv_utils.hpp; keep the single extern here.
 extern "C" {
    __attribute__((sysio_wasm_import))
-   int64_t kv_set(uint32_t table_id, uint64_t payer, const void* key, uint32_t key_size, const void* value, uint32_t value_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_get(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size, void* value, uint32_t value_size);
-   __attribute__((sysio_wasm_import))
-   int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_contains(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size);
-   __attribute__((sysio_wasm_import))
-   uint32_t kv_it_create(uint32_t table_id, uint64_t code, const void* prefix, uint32_t prefix_size);
-   __attribute__((sysio_wasm_import))
-   void kv_it_destroy(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_status(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_next(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_prev(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_lower_bound(uint32_t handle, const void* key, uint32_t key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
-                     const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_remove(uint32_t table_id, int64_t primary_id,
-                      const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
-                      const void* old_sec_key, uint32_t old_sec_key_size,
-                      const void* new_sec_key, uint32_t new_sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_find_secondary(uint64_t code, uint32_t table_id,
-                                 const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_lower_bound(uint64_t code, uint32_t table_id,
-                              const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_next(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_prev(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_primary_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_destroy(uint32_t handle);
+   int32_t kv_get(uint32_t table_id, uint64_t code,
+                  const void* key, uint32_t key_size,
+                  void* value, uint32_t value_size);
 }
 
 #include <sysio/name.hpp>
@@ -822,9 +778,11 @@ public:
       // Helper: read primary key from secondary iterator handle.
       // kv_idx_primary_key returns the full kv_object key bytes — for
       // kv_multi_index the primary row's key is [scope:8B][pk:8B] (16 bytes).
-      // We read both, verify the scope matches this view's scope, and return
-      // the unscoped pk portion so the caller sees the same uint64 they'd
-      // get from the row's primary_key() accessor.
+      // The scope prefix is assumed to match this view's scope: kv_multi_index
+      // writes both the sec row and the referenced primary in the same scope,
+      // so any sec handle reachable from this view points at a primary in the
+      // same scope. We return the unscoped pk portion so the caller sees the
+      // same uint64 they'd get from the row's primary_key() accessor.
       static bool read_primary_key(uint32_t handle, uint64_t& pk) {
          constexpr uint32_t full_size = _kv_multi_index_detail::scope_size
                                       + _kv_multi_index_detail::u64_size;

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -43,16 +43,13 @@ extern "C" {
    __attribute__((sysio_wasm_import))
    int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
    __attribute__((sysio_wasm_import))
-   void kv_idx_store(uint64_t payer, uint32_t table_id,
-                     const void* pri_key, uint32_t pri_key_size,
+   void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
                      const void* sec_key, uint32_t sec_key_size);
    __attribute__((sysio_wasm_import))
-   void kv_idx_remove(uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
+   void kv_idx_remove(uint32_t table_id, int64_t primary_id,
                       const void* sec_key, uint32_t sec_key_size);
    __attribute__((sysio_wasm_import))
-   void kv_idx_update(uint64_t payer, uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
+   void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
                       const void* old_sec_key, uint32_t old_sec_key_size,
                       const void* new_sec_key, uint32_t new_sec_key_size);
    __attribute__((sysio_wasm_import))
@@ -363,55 +360,48 @@ class kv_multi_index {
    struct secondary_ops {
       static constexpr uint32_t _sec_tid = sysio::kv::compute_mi_sec_table_id(static_cast<uint64_t>(TableName), N);
 
-      static void store_all(uint64_t payer, const kv_multi_index& idx, const T& obj) {
+      static void store_all(uint64_t payer, const kv_multi_index& idx, int64_t primary_id, const T& obj) {
          using extractor_t = typename Index::secondary_extractor_type;
          extractor_t ext;
          auto sec_key = idx.encode_scoped_secondary(ext(obj));
-         auto pri_key = idx.pk_to_bytes(obj.primary_key());
-         ::kv_idx_store(payer, _sec_tid,
-                        pri_key.data, _kv_multi_index_detail::u64_size,
-                        sec_key.data(), sec_key.size());
+         ::kv_idx_store(payer, _sec_tid, primary_id, sec_key.data(), sec_key.size());
          if constexpr (sizeof...(Rest) > 0) {
-            secondary_ops<N+1, Rest...>::store_all(payer, idx, obj);
+            secondary_ops<N+1, Rest...>::store_all(payer, idx, primary_id, obj);
          }
       }
 
-      static void remove_all(const kv_multi_index& idx, const T& obj) {
+      static void remove_all(const kv_multi_index& idx, int64_t primary_id, const T& obj) {
          using extractor_t = typename Index::secondary_extractor_type;
          extractor_t ext;
          auto sec_key = idx.encode_scoped_secondary(ext(obj));
-         auto pri_key = idx.pk_to_bytes(obj.primary_key());
-         ::kv_idx_remove(_sec_tid,
-                         pri_key.data, _kv_multi_index_detail::u64_size,
-                         sec_key.data(), sec_key.size());
+         ::kv_idx_remove(_sec_tid, primary_id, sec_key.data(), sec_key.size());
          if constexpr (sizeof...(Rest) > 0) {
-            secondary_ops<N+1, Rest...>::remove_all(idx, obj);
+            secondary_ops<N+1, Rest...>::remove_all(idx, primary_id, obj);
          }
       }
 
-      static void update_all(uint64_t payer, const kv_multi_index& idx, const T& old_obj, const T& new_obj) {
+      static void update_all(uint64_t payer, const kv_multi_index& idx,
+                             int64_t primary_id, const T& old_obj, const T& new_obj) {
          using extractor_t = typename Index::secondary_extractor_type;
          extractor_t ext;
          auto old_sec = idx.encode_scoped_secondary(ext(old_obj));
          auto new_sec = idx.encode_scoped_secondary(ext(new_obj));
-         auto pri_key = idx.pk_to_bytes(old_obj.primary_key());
          if (old_sec != new_sec) {
-            ::kv_idx_update(payer, _sec_tid,
-                            pri_key.data, _kv_multi_index_detail::u64_size,
+            ::kv_idx_update(payer, _sec_tid, primary_id,
                             old_sec.data(), old_sec.size(),
                             new_sec.data(), new_sec.size());
          }
          if constexpr (sizeof...(Rest) > 0) {
-            secondary_ops<N+1, Rest...>::update_all(payer, idx, old_obj, new_obj);
+            secondary_ops<N+1, Rest...>::update_all(payer, idx, primary_id, old_obj, new_obj);
          }
       }
    };
 
    // Base case — no indices
    struct no_secondary_ops {
-      static void store_all(uint64_t, const kv_multi_index&, const T&) {}
-      static void remove_all(const kv_multi_index&, const T&) {}
-      static void update_all(uint64_t, const kv_multi_index&, const T&, const T&) {}
+      static void store_all(uint64_t, const kv_multi_index&, int64_t, const T&) {}
+      static void remove_all(const kv_multi_index&, int64_t, const T&) {}
+      static void update_all(uint64_t, const kv_multi_index&, int64_t, const T&, const T&) {}
    };
 
    template<typename... Is>
@@ -420,16 +410,16 @@ class kv_multi_index {
    struct sec_ops_selector<> { using type = no_secondary_ops; };
    using sec_ops = typename sec_ops_selector<Indices...>::type;
 
-   void store_secondaries(uint64_t payer, const T& obj) const {
-      sec_ops::store_all(payer, *this, obj);
+   void store_secondaries(uint64_t payer, int64_t primary_id, const T& obj) const {
+      sec_ops::store_all(payer, *this, primary_id, obj);
    }
 
-   void remove_secondaries(const T& obj) const {
-      sec_ops::remove_all(*this, obj);
+   void remove_secondaries(int64_t primary_id, const T& obj) const {
+      sec_ops::remove_all(*this, primary_id, obj);
    }
 
-   void update_secondaries(uint64_t payer, const T& old_obj, const T& new_obj) const {
-      sec_ops::update_all(payer, *this, old_obj, new_obj);
+   void update_secondaries(uint64_t payer, int64_t primary_id, const T& old_obj, const T& new_obj) const {
+      sec_ops::update_all(payer, *this, primary_id, old_obj, new_obj);
    }
 
 public:
@@ -682,8 +672,8 @@ public:
       auto key = make_pk(pk);
       auto value = serialize_row(obj);
 
-      ::kv_set(_table_id, payer.value, key.data, key_size, value.data(), value.size());
-      store_secondaries(payer.value, obj);
+      int64_t primary_id = ::kv_set(_table_id, payer.value, key.data, key_size, value.data(), value.size());
+      store_secondaries(payer.value, primary_id, obj);
 
       // Cache the object
       auto ptr = std::make_unique<T>(std::move(obj));
@@ -716,9 +706,9 @@ public:
       uint64_t pk = to_pk_uint64(mutable_obj.primary_key());
       auto key = make_pk(pk);
       auto value = serialize_row(mutable_obj);
-      ::kv_set(_table_id, payer.value, key.data, key_size, value.data(), value.size());
+      int64_t primary_id = ::kv_set(_table_id, payer.value, key.data, key_size, value.data(), value.size());
 
-      update_secondaries(payer.value, old_obj, mutable_obj);
+      update_secondaries(payer.value, primary_id, old_obj, mutable_obj);
 
       // Update cache
       _items[pk] = std::make_unique<T>(mutable_obj);
@@ -737,8 +727,10 @@ public:
       uint64_t pk = to_pk_uint64(obj.primary_key());
       auto key = make_pk(pk);
 
-      remove_secondaries(obj);
-      ::kv_erase(_table_id, key.data, key_size);
+      // kv_erase returns the primary_id needed to locate each secondary row
+      // under the new (code, sec_tid, sec_key, primary_id) composite key.
+      int64_t primary_id = ::kv_erase(_table_id, key.data, key_size);
+      remove_secondaries(primary_id, obj);
       _items.erase(pk);
    }
 
@@ -828,13 +820,19 @@ public:
       secondary_index_view(const kv_multi_index& mi) : _mi(&mi) {}
 
       // Helper: read primary key from secondary iterator handle.
-      // The stored pri_key is [pk:8B].
+      // kv_idx_primary_key returns the full kv_object key bytes — for
+      // kv_multi_index the primary row's key is [scope:8B][pk:8B] (16 bytes).
+      // We read both, verify the scope matches this view's scope, and return
+      // the unscoped pk portion so the caller sees the same uint64 they'd
+      // get from the row's primary_key() accessor.
       static bool read_primary_key(uint32_t handle, uint64_t& pk) {
-         char pri_buf[_kv_multi_index_detail::u64_size];
+         constexpr uint32_t full_size = _kv_multi_index_detail::scope_size
+                                      + _kv_multi_index_detail::u64_size;
+         char pri_buf[full_size];
          uint32_t actual = 0;
-         int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, _kv_multi_index_detail::u64_size, &actual);
-         if (status != 0 || actual != _kv_multi_index_detail::u64_size) return false;
-         pk = _kv_multi_index_detail::decode_be64(pri_buf);
+         int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, full_size, &actual);
+         if (status != 0 || actual != full_size) return false;
+         pk = _kv_multi_index_detail::decode_be64(pri_buf + _kv_multi_index_detail::scope_size);
          return true;
       }
 

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -14,17 +14,8 @@
  */
 
 #include <cstdint>
-#include <sysio/kv_utils.hpp>                   // primary KV + iterator intrinsics
+#include <sysio/kv_utils.hpp>                   // primary KV + iterator intrinsics (declares kv_get)
 #include <sysio/detail/kv_idx_intrinsics.hpp>   // secondary-index intrinsics
-
-// kv_get is used for the primary-row-cache load path but is not declared in
-// kv_utils.hpp; keep the single extern here.
-extern "C" {
-   __attribute__((sysio_wasm_import))
-   int32_t kv_get(uint32_t table_id, uint64_t code,
-                  const void* key, uint32_t key_size,
-                  void* value, uint32_t value_size);
-}
 
 #include <sysio/name.hpp>
 #include <sysio/serialize.hpp>
@@ -154,6 +145,8 @@ namespace _kv_multi_index_detail {
 template<name::raw TableName, typename T, typename... Indices>
 class kv_multi_index {
    static_assert(sizeof...(Indices) <= 16, "multi_index supports at most 16 secondary indices");
+   static_assert(std::is_default_constructible_v<T>,
+                 "kv_multi_index row type must be default-constructible; add a default ctor to T");
 
    /// table_id computed at compile time from the template parameter.
    static constexpr uint32_t _table_id = sysio::kv::compute_table_id(static_cast<uint64_t>(TableName));
@@ -252,10 +245,9 @@ class kv_multi_index {
       if (sz <= static_cast<int32_t>(sysio::kv::kv_value_stack_size)) {
          obj = deserialize_row(stack, sz);
       } else {
-         char* heap = new char[sz];
-         ::kv_get(_table_id, _code.value, key.data, key_size, heap, sz);
-         obj = deserialize_row(heap, sz);
-         delete[] heap;
+         sysio::kv::ser_buf heap_buf(static_cast<uint32_t>(sz));
+         ::kv_get(_table_id, _code.value, key.data, key_size, heap_buf.data(), sz);
+         obj = deserialize_row(heap_buf.data(), sz);
       }
 
       auto ptr = std::make_unique<T>(std::move(obj));
@@ -778,18 +770,22 @@ public:
       // Helper: read primary key from secondary iterator handle.
       // kv_idx_primary_key returns the full kv_object key bytes — for
       // kv_multi_index the primary row's key is [scope:8B][pk:8B] (16 bytes).
-      // The scope prefix is assumed to match this view's scope: kv_multi_index
-      // writes both the sec row and the referenced primary in the same scope,
-      // so any sec handle reachable from this view points at a primary in the
-      // same scope. We return the unscoped pk portion so the caller sees the
-      // same uint64 they'd get from the row's primary_key() accessor.
-      static bool read_primary_key(uint32_t handle, uint64_t& pk) {
+      // kv_multi_index writes both the sec row and its referenced primary in
+      // the same scope, so any sec handle reachable from a given view must
+      // resolve to a primary in that view's scope. The caller passes the
+      // expected scope and we check() that the decoded scope matches before
+      // returning the pk portion — a cross-scope resolution is a host or
+      // wrapper bug, not a normal end-of-range condition.
+      static bool read_primary_key(uint32_t handle, uint64_t expected_scope, uint64_t& pk) {
          constexpr uint32_t full_size = _kv_multi_index_detail::scope_size
                                       + _kv_multi_index_detail::u64_size;
          char pri_buf[full_size];
          uint32_t actual = 0;
          int32_t status = ::kv_idx_primary_key(handle, 0, pri_buf, full_size, &actual);
          if (status != 0 || actual != full_size) return false;
+         const uint64_t got_scope = _kv_multi_index_detail::decode_be64(pri_buf);
+         check(got_scope == expected_scope,
+               "kv_multi_index: secondary handle resolved to primary in a different scope");
          pk = _kv_multi_index_detail::decode_be64(pri_buf + _kv_multi_index_detail::scope_size);
          return true;
       }
@@ -882,10 +878,10 @@ public:
                // secondary key, but the source iterator may point to a later
                // duplicate. Advance until we find the matching primary key.
                uint64_t found_pk = 0;
-               if (read_primary_key(_handle, found_pk) && found_pk == _pk)
+               if (read_primary_key(_handle, _mi->_scope, found_pk) && found_pk == _pk)
                   return;
                while (::kv_idx_next(_handle) == 0) {
-                  if (read_primary_key(_handle, found_pk) && found_pk == _pk)
+                  if (read_primary_key(_handle, _mi->_scope, found_pk) && found_pk == _pk)
                      return;
                }
             } else {
@@ -910,7 +906,7 @@ public:
 
          void load_current() {
             if (_handle < 0) { _has_obj = false; return; }
-            if (!read_primary_key(_handle, _pk)) { _has_obj = false; return; }
+            if (!read_primary_key(_handle, _mi->_scope, _pk)) { _has_obj = false; return; }
             auto* ptr = _mi->load_object(_pk);
             if (ptr) { _obj = *ptr; _has_obj = true; }
             else { _has_obj = false; }

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -1101,7 +1101,7 @@ public:
 
             // Fetch the row's value directly via the secondary iterator
             // (kv_it_value accepts secondary handles and uses the cached
-            // primary_id for an O(1) by_id lookup — faster than kv_get's
+            // primary_id for a by_id lookup — faster than kv_get's
             // by_code_key walk and avoids reconstructing the scoped key).
             if constexpr (is_fixed_serializable_v<V>) {
                char vbuf[sizeof(V)];

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -43,16 +43,13 @@
 // is also included.
 extern "C" {
    __attribute__((sysio_wasm_import))
-   void kv_idx_store(uint64_t payer, uint32_t table_id,
-                     const void* pri_key, uint32_t pri_key_size,
+   void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
                      const void* sec_key, uint32_t sec_key_size);
    __attribute__((sysio_wasm_import))
-   void kv_idx_remove(uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
+   void kv_idx_remove(uint32_t table_id, int64_t primary_id,
                       const void* sec_key, uint32_t sec_key_size);
    __attribute__((sysio_wasm_import))
-   void kv_idx_update(uint64_t payer, uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
+   void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
                       const void* old_sec_key, uint32_t old_sec_key_size,
                       const void* new_sec_key, uint32_t new_sec_key_size);
    __attribute__((sysio_wasm_import))
@@ -402,29 +399,27 @@ public:
          static_cast<uint64_t>(TableName), Index::index_name);
 
       static void store_all(const table_impl& tbl, uint64_t payer,
-                            const char* pri_data, uint32_t pri_size, const V& value) {
+                            int64_t primary_id, const V& value) {
          using ext_t = typename Index::secondary_extractor_type;
          ext_t ext;
          auto sec = tbl.encode_sec_key(ext(value));
-         ::kv_idx_store(payer, _sec_tid,
-                        pri_data, pri_size, sec.data(), sec.size());
+         ::kv_idx_store(payer, _sec_tid, primary_id, sec.data(), sec.size());
          if constexpr (sizeof...(Rest) > 0)
-            secondary_ops<N+1, Rest...>::store_all(tbl, payer, pri_data, pri_size, value);
+            secondary_ops<N+1, Rest...>::store_all(tbl, payer, primary_id, value);
       }
 
       static void remove_all(const table_impl& tbl,
-                             const char* pri_data, uint32_t pri_size, const V& value) {
+                             int64_t primary_id, const V& value) {
          using ext_t = typename Index::secondary_extractor_type;
          ext_t ext;
          auto sec = tbl.encode_sec_key(ext(value));
-         ::kv_idx_remove(_sec_tid,
-                         pri_data, pri_size, sec.data(), sec.size());
+         ::kv_idx_remove(_sec_tid, primary_id, sec.data(), sec.size());
          if constexpr (sizeof...(Rest) > 0)
-            secondary_ops<N+1, Rest...>::remove_all(tbl, pri_data, pri_size, value);
+            secondary_ops<N+1, Rest...>::remove_all(tbl, primary_id, value);
       }
 
       static void update_all(const table_impl& tbl, uint64_t payer,
-                              const char* pri_data, uint32_t pri_size,
+                              int64_t primary_id,
                               const V& old_val, const V& new_val) {
          using ext_t = typename Index::secondary_extractor_type;
          ext_t ext;
@@ -433,20 +428,19 @@ public:
          bool same = (old_sec.size() == new_sec.size()) &&
                      (old_sec.size() == 0 || std::memcmp(old_sec.data(), new_sec.data(), old_sec.size()) == 0);
          if (!same) {
-            ::kv_idx_update(payer, _sec_tid,
-                            pri_data, pri_size,
+            ::kv_idx_update(payer, _sec_tid, primary_id,
                             old_sec.data(), old_sec.size(),
                             new_sec.data(), new_sec.size());
          }
          if constexpr (sizeof...(Rest) > 0)
-            secondary_ops<N+1, Rest...>::update_all(tbl, payer, pri_data, pri_size, old_val, new_val);
+            secondary_ops<N+1, Rest...>::update_all(tbl, payer, primary_id, old_val, new_val);
       }
    };
 
    struct no_secondary_ops {
-      static void store_all(const table_impl&, uint64_t, const char*, uint32_t, const V&) {}
-      static void remove_all(const table_impl&, const char*, uint32_t, const V&) {}
-      static void update_all(const table_impl&, uint64_t, const char*, uint32_t, const V&, const V&) {}
+      static void store_all(const table_impl&, uint64_t, int64_t, const V&) {}
+      static void remove_all(const table_impl&, int64_t, const V&) {}
+      static void update_all(const table_impl&, uint64_t, int64_t, const V&, const V&) {}
    };
 
    template<typename... Is>
@@ -455,38 +449,42 @@ public:
    struct sec_ops_selector<> { using type = no_secondary_ops; };
    using sec_ops = typename sec_ops_selector<Indices...>::type;
 
-   /// Secondary ops use unscoped pri_key — saves 8B/row vs storing scoped key.
-   void store_secondaries(uint64_t payer, const K& key, const V& value) {
-      auto pri = make_unscoped_key(key);
-      sec_ops::store_all(*this, payer, pri.data(), pri.size(), value);
+   // Secondary rows reference the primary row by chainbase id (returned by
+   // kv_set/kv_erase). The primary-key bytes themselves are no longer copied
+   // into each secondary row, which saves RAM proportional to pri_key size x
+   // number of secondary indexes.
+   void store_secondaries(uint64_t payer, int64_t primary_id, const V& value) {
+      sec_ops::store_all(*this, payer, primary_id, value);
    }
-   void remove_secondaries(const K& key, const V& value) {
-      auto pri = make_unscoped_key(key);
-      sec_ops::remove_all(*this, pri.data(), pri.size(), value);
+   void remove_secondaries(int64_t primary_id, const V& value) {
+      sec_ops::remove_all(*this, primary_id, value);
    }
-   void update_secondaries(uint64_t payer, const K& key, const V& old_val, const V& new_val) {
-      auto pri = make_unscoped_key(key);
-      sec_ops::update_all(*this, payer, pri.data(), pri.size(), old_val, new_val);
+   void update_secondaries(uint64_t payer, int64_t primary_id, const V& old_val, const V& new_val) {
+      sec_ops::update_all(*this, payer, primary_id, old_val, new_val);
    }
 
-   // Internal insert (no duplicate check — caller must verify)
-   void do_insert(uint64_t payer, const be_key_stream& k, const K& key, const V& value) {
+   // Internal insert (no duplicate check — caller must verify). kv_set returns
+   // the newly-assigned primary_id which we thread into each secondary row.
+   void do_insert(uint64_t payer, const be_key_stream& k, const V& value) {
+      int64_t primary_id;
       if constexpr (is_fixed_serializable_v<V>) {
          char vbuf[sizeof(V)];
          std::memcpy(vbuf, &value, sizeof(V));
-         ::kv_set(_table_id, payer, k.data(), k.size(), vbuf, sizeof(V));
+         primary_id = ::kv_set(_table_id, payer, k.data(), k.size(), vbuf, sizeof(V));
       } else {
          auto v = serialize_value(value);
-         ::kv_set(_table_id, payer, k.data(), k.size(), v.data(), v.size());
+         primary_id = ::kv_set(_table_id, payer, k.data(), k.size(), v.data(), v.size());
       }
-      store_secondaries(payer, key, value);
+      store_secondaries(payer, primary_id, value);
    }
 
-   // Internal erase used by both primary and secondary erase paths
+   // Internal erase used by both primary and secondary erase paths. kv_erase
+   // runs first so we learn the primary_id needed to find each secondary row
+   // under the composite (code, sec_tid, sec_key, primary_id) key.
    void do_erase(const K& key, const V& value) {
-      remove_secondaries(key, value);
       auto pri = make_key(key);
-      ::kv_erase(_table_id, pri.data(), pri.size());
+      int64_t primary_id = ::kv_erase(_table_id, pri.data(), pri.size());
+      remove_secondaries(primary_id, value);
    }
 
 public:
@@ -729,7 +727,7 @@ public:
    void emplace(name payer, const K& key, const V& value, const char* exists_msg = "key already exists") {
       auto k = make_key(key);
       sysio::check(!::kv_contains(_table_id, code(), k.data(), k.size()), exists_msg);
-      do_insert(payer.value, k, key, value);
+      do_insert(payer.value, k, value);
    }
 
    void emplace(const K& key, const V& value) {
@@ -762,18 +760,19 @@ public:
       if constexpr (is_fixed_serializable_v<V>) {
          char old_vbuf[sizeof(V)];
          int32_t old_sz = ::kv_get(_table_id, code(), k.data(), k.size(), old_vbuf, sizeof(V));
-         if (old_sz >= 0) {
-            V old_value; std::memcpy(&old_value, old_vbuf, sizeof(V));
-            update_secondaries(payer.value, key, old_value, value);
-         } else {
-            store_secondaries(payer.value, key, value);
-         }
          char vbuf[sizeof(V)];
          std::memcpy(vbuf, &value, sizeof(V));
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         int64_t primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         if (old_sz >= 0) {
+            V old_value; std::memcpy(&old_value, old_vbuf, sizeof(V));
+            update_secondaries(payer.value, primary_id, old_value, value);
+         } else {
+            store_secondaries(payer.value, primary_id, value);
+         }
       } else {
          char stack[kv_value_stack_size];
          int32_t old_sz = ::kv_get(_table_id, code(), k.data(), k.size(), stack, kv_value_stack_size);
+         V old_value;
          if (old_sz >= 0) {
             const char* old_data = stack;
             char* heap = nullptr;
@@ -782,14 +781,16 @@ public:
                ::kv_get(_table_id, code(), k.data(), k.size(), heap, old_sz);
                old_data = heap;
             }
-            V old_value = deserialize_value(old_data, old_sz);
+            old_value = deserialize_value(old_data, old_sz);
             delete[] heap;
-            update_secondaries(payer.value, key, old_value, value);
-         } else {
-            store_secondaries(payer.value, key, value);
          }
          auto v = serialize_value(value);
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+         int64_t primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+         if (old_sz >= 0) {
+            update_secondaries(payer.value, primary_id, old_value, value);
+         } else {
+            store_secondaries(payer.value, primary_id, value);
+         }
       }
    }
 
@@ -814,22 +815,27 @@ public:
          char old_vbuf[sizeof(V)];
          int32_t old_sz = ::kv_get(_table_id, code(), k.data(), k.size(), old_vbuf, sizeof(V));
          V new_value;
+         V old_value;
          if (old_sz >= 0) {
-            V old_value; std::memcpy(&old_value, old_vbuf, sizeof(V));
+            std::memcpy(&old_value, old_vbuf, sizeof(V));
             new_value = old_value;
             updater(new_value);
-            update_secondaries(payer.value, key, old_value, new_value);
          } else {
             new_value = default_value;
-            store_secondaries(payer.value, key, new_value);
          }
          char vbuf[sizeof(V)];
          std::memcpy(vbuf, &new_value, sizeof(V));
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         int64_t primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         if (old_sz >= 0) {
+            update_secondaries(payer.value, primary_id, old_value, new_value);
+         } else {
+            store_secondaries(payer.value, primary_id, new_value);
+         }
       } else {
          char stack[kv_value_stack_size];
          int32_t old_sz = ::kv_get(_table_id, code(), k.data(), k.size(), stack, kv_value_stack_size);
          V new_value;
+         V old_value;
          if (old_sz >= 0) {
             const char* old_data = stack;
             char* heap = nullptr;
@@ -838,17 +844,20 @@ public:
                ::kv_get(_table_id, code(), k.data(), k.size(), heap, old_sz);
                old_data = heap;
             }
-            V old_value = deserialize_value(old_data, old_sz);
+            old_value = deserialize_value(old_data, old_sz);
             delete[] heap;
             new_value = old_value;
             updater(new_value);
-            update_secondaries(payer.value, key, old_value, new_value);
          } else {
             new_value = default_value;
-            store_secondaries(payer.value, key, new_value);
          }
          auto v = serialize_value(new_value);
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+         int64_t primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+         if (old_sz >= 0) {
+            update_secondaries(payer.value, primary_id, old_value, new_value);
+         } else {
+            store_secondaries(payer.value, primary_id, new_value);
+         }
       }
    }
 
@@ -860,15 +869,16 @@ public:
    void modify(name payer, const const_iterator& it, const V& new_value) {
       sysio::check(it._valid, "cannot modify end iterator");
       auto k = make_key(it._row.key);
-      update_secondaries(payer.value, it._row.key, it._row.value, new_value);
+      int64_t primary_id;
       if constexpr (is_fixed_serializable_v<V>) {
          char vbuf[sizeof(V)];
          std::memcpy(vbuf, &new_value, sizeof(V));
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
       } else {
          auto v = serialize_value(new_value);
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+         primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
       }
+      update_secondaries(payer.value, primary_id, it._row.value, new_value);
    }
 
    void modify(const const_iterator& it, const V& new_value) {
@@ -882,15 +892,16 @@ public:
       V new_val = old_val;
       updater(new_val);
       auto k = make_key(key);
-      update_secondaries(payer.value, key, old_val, new_val);
+      int64_t primary_id;
       if constexpr (is_fixed_serializable_v<V>) {
          char vbuf[sizeof(V)];
          std::memcpy(vbuf, &new_val, sizeof(V));
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+         primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
       } else {
          auto v = serialize_value(new_val);
-         ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+         primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
       }
+      update_secondaries(payer.value, primary_id, old_val, new_val);
    }
 
    template<typename Lambda>
@@ -1093,44 +1104,49 @@ public:
 
          void load_current() {
             if (_handle < 0) { _valid = false; return; }
-            char pri_stack[key_buf::inline_cap];
-            uint32_t pri_size = 0;
-            if (::kv_idx_primary_key(_handle, 0, pri_stack, key_buf::inline_cap, &pri_size) != 0) {
+            // kv_idx_primary_key returns the FULL primary kv_object key bytes,
+            // i.e. the scope prefix plus the in-scope key bytes for scoped
+            // tables. Strip the scope prefix to recover the unscoped bytes
+            // the contract originally emitted.
+            constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
+            char pri_stack[key_buf::inline_cap + kv_scope_size];
+            uint32_t full_size = 0;
+            if (::kv_idx_primary_key(_handle, 0, pri_stack, sizeof(pri_stack), &full_size) != 0) {
                _valid = false; return;
             }
-            if (pri_size <= key_buf::inline_cap) {
-               _pri_bytes.assign(pri_stack, pri_size);
+            if (full_size <= sizeof(pri_stack)) {
+               if (full_size < scope_sz) { _valid = false; return; }
+               _pri_bytes.assign(pri_stack + scope_sz, full_size - scope_sz);
             } else {
-               char* ph = new char[pri_size];
-               ::kv_idx_primary_key(_handle, 0, ph, pri_size, &pri_size);
-               _pri_bytes.assign(ph, pri_size);
+               char* ph = new char[full_size];
+               ::kv_idx_primary_key(_handle, 0, ph, full_size, &full_size);
+               if (full_size < scope_sz) { delete[] ph; _valid = false; return; }
+               _pri_bytes.assign(ph + scope_sz, full_size - scope_sz);
                delete[] ph;
             }
-            // pri_bytes is unscoped [K] — decode directly
+            // pri_bytes now holds the unscoped [K] portion — decode directly.
             _row.key = decode_unscoped_key(_pri_bytes.data(), _pri_bytes.size());
 
-            // Reconstruct full scoped key for kv_get
-            auto full = _tbl->make_full_key_from_pri(_pri_bytes.data(), _pri_bytes.size());
-
+            // Fetch the row's value directly via the secondary iterator
+            // (kv_it_value accepts secondary handles and uses the cached
+            // primary_id for an O(1) by_id lookup — faster than kv_get's
+            // by_code_key walk and avoids reconstructing the scoped key).
             if constexpr (is_fixed_serializable_v<V>) {
                char vbuf[sizeof(V)];
-               int32_t val_sz = ::kv_get(_table_id, _tbl->code(),
-                                         full.data(), full.size(),
-                                         vbuf, sizeof(V));
-               if (val_sz < 0) { _valid = false; return; }
+               uint32_t val_sz = 0;
+               int32_t st = ::kv_it_value(_handle, 0, vbuf, sizeof(V), &val_sz);
+               if (st != 0) { _valid = false; return; }
                std::memcpy(&_row.value, vbuf, sizeof(V));
             } else {
                char val_stack[kv_value_stack_size];
-               int32_t val_sz = ::kv_get(_table_id, _tbl->code(),
-                                         full.data(), full.size(),
-                                         val_stack, kv_value_stack_size);
-               if (val_sz < 0) { _valid = false; return; }
-               if (val_sz <= static_cast<int32_t>(kv_value_stack_size)) {
+               uint32_t val_sz = 0;
+               int32_t st = ::kv_it_value(_handle, 0, val_stack, kv_value_stack_size, &val_sz);
+               if (st != 0) { _valid = false; return; }
+               if (val_sz <= kv_value_stack_size) {
                   _row.value = deserialize_value(val_stack, val_sz);
                } else {
                   char* heap = new char[val_sz];
-                  ::kv_get(_table_id, _tbl->code(),
-                           full.data(), full.size(), heap, val_sz);
+                  ::kv_it_value(_handle, 0, heap, val_sz, &val_sz);
                   _row.value = deserialize_value(heap, val_sz);
                   delete[] heap;
                }
@@ -1231,20 +1247,26 @@ public:
 
          void load_keys() {
             if (_handle < 0) { _valid = false; return; }
-            char pri_stack[key_buf::inline_cap];
-            uint32_t pri_size = 0;
-            if (::kv_idx_primary_key(_handle, 0, pri_stack, key_buf::inline_cap, &pri_size) != 0) {
+            // kv_idx_primary_key returns the full scoped key; strip the scope
+            // prefix (8 bytes for scoped tables, 0 otherwise) to recover the
+            // unscoped bytes the contract originally emitted.
+            constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
+            char pri_stack[key_buf::inline_cap + kv_scope_size];
+            uint32_t full_size = 0;
+            if (::kv_idx_primary_key(_handle, 0, pri_stack, sizeof(pri_stack), &full_size) != 0) {
                _valid = false; return;
             }
-            if (pri_size <= key_buf::inline_cap) {
-               _pri_bytes.assign(pri_stack, pri_size);
+            if (full_size <= sizeof(pri_stack)) {
+               if (full_size < scope_sz) { _valid = false; return; }
+               _pri_bytes.assign(pri_stack + scope_sz, full_size - scope_sz);
             } else {
-               char* ph = new char[pri_size];
-               ::kv_idx_primary_key(_handle, 0, ph, pri_size, &pri_size);
-               _pri_bytes.assign(ph, pri_size);
+               char* ph = new char[full_size];
+               ::kv_idx_primary_key(_handle, 0, ph, full_size, &full_size);
+               if (full_size < scope_sz) { delete[] ph; _valid = false; return; }
+               _pri_bytes.assign(ph + scope_sz, full_size - scope_sz);
                delete[] ph;
             }
-            // pri_bytes is unscoped [K] — decode directly
+            // pri_bytes now holds the unscoped [K] portion — decode directly.
             _kr.key = decode_unscoped_key(_pri_bytes.data(), _pri_bytes.size());
 
             char sec_stack[64];
@@ -1347,16 +1369,16 @@ public:
       void modify(name payer, const const_iterator& itr, const V& new_value) {
          sysio::check(itr._valid, "cannot modify end iterator");
          auto k = _tbl->make_key(itr._row.key);
-         _tbl->update_secondaries(
-            payer.value, itr._row.key, itr._row.value, new_value);
+         int64_t primary_id;
          if constexpr (is_fixed_serializable_v<V>) {
             char vbuf[sizeof(V)];
             std::memcpy(vbuf, &new_value, sizeof(V));
-            ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
+            primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), vbuf, sizeof(V));
          } else {
             auto v = serialize_value(new_value);
-            ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
+            primary_id = ::kv_set(_table_id, payer.value, k.data(), k.size(), v.data(), v.size());
          }
+         _tbl->update_secondaries(payer.value, primary_id, itr._row.value, new_value);
       }
 
       void modify(const const_iterator& itr, const V& new_value) {

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -29,7 +29,8 @@
  *   auto it  = idx.find("alice"_n);
  */
 
-#include <sysio/kv_utils.hpp>
+#include <sysio/kv_utils.hpp>                   // primary KV + iterator intrinsics
+#include <sysio/detail/kv_idx_intrinsics.hpp>   // secondary-index intrinsics
 #include <sysio/check.hpp>
 
 #include <cstring>
@@ -37,38 +38,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-// Secondary index intrinsic declarations (not in kv_utils.hpp).
-// Duplicate extern "C" declarations are harmless if kv_multi_index.hpp
-// is also included.
-extern "C" {
-   __attribute__((sysio_wasm_import))
-   void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id,
-                     const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_remove(uint32_t table_id, int64_t primary_id,
-                      const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id,
-                      const void* old_sec_key, uint32_t old_sec_key_size,
-                      const void* new_sec_key, uint32_t new_sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_find_secondary(uint64_t code, uint32_t table_id,
-                                 const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_lower_bound(uint64_t code, uint32_t table_id,
-                              const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_next(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_prev(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_primary_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_destroy(uint32_t handle);
-}
 
 namespace sysio { namespace kv {
 
@@ -1109,6 +1078,9 @@ public:
             // tables. Strip the scope prefix to recover the unscoped bytes
             // the contract originally emitted.
             constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
+            // Stack buffer sized so any key that fits in key_buf::inline_cap
+            // when unscoped still fits here once the scope prefix is included;
+            // spill to heap via the else branch if the key is larger.
             char pri_stack[key_buf::inline_cap + kv_scope_size];
             uint32_t full_size = 0;
             if (::kv_idx_primary_key(_handle, 0, pri_stack, sizeof(pri_stack), &full_size) != 0) {
@@ -1251,6 +1223,9 @@ public:
             // prefix (8 bytes for scoped tables, 0 otherwise) to recover the
             // unscoped bytes the contract originally emitted.
             constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
+            // Stack buffer sized so any key that fits in key_buf::inline_cap
+            // when unscoped still fits here once the scope prefix is included;
+            // spill to heap via the else branch if the key is larger.
             char pri_stack[key_buf::inline_cap + kv_scope_size];
             uint32_t full_size = 0;
             if (::kv_idx_primary_key(_handle, 0, pri_stack, sizeof(pri_stack), &full_size) != 0) {

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -972,6 +972,33 @@ public:
          }
       }
 
+      /// Load the unscoped primary key bytes for the row referenced by a
+      /// secondary handle. kv_idx_primary_key returns the FULL primary
+      /// kv_object key (scope prefix + unscoped bytes for scoped tables;
+      /// just the unscoped bytes otherwise); this strips the scope prefix
+      /// and writes the result to `out`. Returns false on read error or a
+      /// short result that can't contain the scope prefix.
+      static bool load_unscoped_primary(int32_t handle, key_buf& out) {
+         constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
+         // Sized so any unscoped key that fits in key_buf::inline_cap also
+         // fits here with the scope prefix; spill to heap below otherwise.
+         char stack[key_buf::inline_cap + kv_scope_size];
+         uint32_t full_size = 0;
+         if (::kv_idx_primary_key(handle, 0, stack, sizeof(stack), &full_size) != 0) return false;
+
+         const char* full_key = stack;
+         char* heap = nullptr;
+         if (full_size > sizeof(stack)) {
+            heap = new char[full_size];
+            ::kv_idx_primary_key(handle, 0, heap, full_size, &full_size);
+            full_key = heap;
+         }
+         const bool ok = full_size >= scope_sz;
+         if (ok) out.assign(full_key + scope_sz, full_size - scope_sz);
+         delete[] heap;
+         return ok;
+      }
+
       // --- key_row for key-only iteration ---
       struct key_row {
          K              key;
@@ -1073,30 +1100,9 @@ public:
 
          void load_current() {
             if (_handle < 0) { _valid = false; return; }
-            // kv_idx_primary_key returns the FULL primary kv_object key bytes,
-            // i.e. the scope prefix plus the in-scope key bytes for scoped
-            // tables. Strip the scope prefix to recover the unscoped bytes
-            // the contract originally emitted.
-            constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
-            // Stack buffer sized so any key that fits in key_buf::inline_cap
-            // when unscoped still fits here once the scope prefix is included;
-            // spill to heap via the else branch if the key is larger.
-            char pri_stack[key_buf::inline_cap + kv_scope_size];
-            uint32_t full_size = 0;
-            if (::kv_idx_primary_key(_handle, 0, pri_stack, sizeof(pri_stack), &full_size) != 0) {
+            if (!secondary_index_view::load_unscoped_primary(_handle, _pri_bytes)) {
                _valid = false; return;
             }
-            if (full_size <= sizeof(pri_stack)) {
-               if (full_size < scope_sz) { _valid = false; return; }
-               _pri_bytes.assign(pri_stack + scope_sz, full_size - scope_sz);
-            } else {
-               char* ph = new char[full_size];
-               ::kv_idx_primary_key(_handle, 0, ph, full_size, &full_size);
-               if (full_size < scope_sz) { delete[] ph; _valid = false; return; }
-               _pri_bytes.assign(ph + scope_sz, full_size - scope_sz);
-               delete[] ph;
-            }
-            // pri_bytes now holds the unscoped [K] portion — decode directly.
             _row.key = decode_unscoped_key(_pri_bytes.data(), _pri_bytes.size());
 
             // Fetch the row's value directly via the secondary iterator
@@ -1219,29 +1225,9 @@ public:
 
          void load_keys() {
             if (_handle < 0) { _valid = false; return; }
-            // kv_idx_primary_key returns the full scoped key; strip the scope
-            // prefix (8 bytes for scoped tables, 0 otherwise) to recover the
-            // unscoped bytes the contract originally emitted.
-            constexpr uint32_t scope_sz = Scoped ? kv_scope_size : 0;
-            // Stack buffer sized so any key that fits in key_buf::inline_cap
-            // when unscoped still fits here once the scope prefix is included;
-            // spill to heap via the else branch if the key is larger.
-            char pri_stack[key_buf::inline_cap + kv_scope_size];
-            uint32_t full_size = 0;
-            if (::kv_idx_primary_key(_handle, 0, pri_stack, sizeof(pri_stack), &full_size) != 0) {
+            if (!secondary_index_view::load_unscoped_primary(_handle, _pri_bytes)) {
                _valid = false; return;
             }
-            if (full_size <= sizeof(pri_stack)) {
-               if (full_size < scope_sz) { _valid = false; return; }
-               _pri_bytes.assign(pri_stack + scope_sz, full_size - scope_sz);
-            } else {
-               char* ph = new char[full_size];
-               ::kv_idx_primary_key(_handle, 0, ph, full_size, &full_size);
-               if (full_size < scope_sz) { delete[] ph; _valid = false; return; }
-               _pri_bytes.assign(ph + scope_sz, full_size - scope_sz);
-               delete[] ph;
-            }
-            // pri_bytes now holds the unscoped [K] portion — decode directly.
             _kr.key = decode_unscoped_key(_pri_bytes.data(), _pri_bytes.size());
 
             char sec_stack[64];

--- a/libraries/sysiolib/contracts/sysio/kv_utils.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_utils.hpp
@@ -10,37 +10,26 @@
 extern "C" {
    __attribute__((sysio_wasm_import))
    int64_t kv_set(uint32_t table_id, uint64_t payer, const void* key, uint32_t key_size, const void* value, uint32_t value_size);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_get(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size, void* value, uint32_t value_size);
-
    __attribute__((sysio_wasm_import))
    int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_contains(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size);
-
    __attribute__((sysio_wasm_import))
    uint32_t kv_it_create(uint32_t table_id, uint64_t code, const void* prefix, uint32_t prefix_size);
-
    __attribute__((sysio_wasm_import))
    void kv_it_destroy(uint32_t handle);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_it_status(uint32_t handle);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_it_next(uint32_t handle);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_it_prev(uint32_t handle);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_it_lower_bound(uint32_t handle, const void* key, uint32_t key_size);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_it_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-
    __attribute__((sysio_wasm_import))
    int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
 }

--- a/libraries/sysiolib/contracts/sysio/kv_utils.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_utils.hpp
@@ -10,26 +10,37 @@
 extern "C" {
    __attribute__((sysio_wasm_import))
    int64_t kv_set(uint32_t table_id, uint64_t payer, const void* key, uint32_t key_size, const void* value, uint32_t value_size);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_get(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size, void* value, uint32_t value_size);
+
    __attribute__((sysio_wasm_import))
    int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_contains(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size);
+
    __attribute__((sysio_wasm_import))
    uint32_t kv_it_create(uint32_t table_id, uint64_t code, const void* prefix, uint32_t prefix_size);
+
    __attribute__((sysio_wasm_import))
    void kv_it_destroy(uint32_t handle);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_it_status(uint32_t handle);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_it_next(uint32_t handle);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_it_prev(uint32_t handle);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_it_lower_bound(uint32_t handle, const void* key, uint32_t key_size);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_it_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
+
    __attribute__((sysio_wasm_import))
    int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
 }

--- a/tests/integration/multi_index_tests.cpp
+++ b/tests/integration/multi_index_tests.cpp
@@ -87,6 +87,7 @@ BOOST_FIXTURE_TEST_CASE(multi_index_tests_part2, TESTER) { try {
 
    // secondary iterator edge cases
    push_action( "testapi2"_n, "s1clone"_n,    "testapi2"_n, {} ); // sec iterator clone with duplicate keys
+   push_action( "testapi2"_n, "s1tieb"_n,     "testapi2"_n, {} ); // sec tiebreaker is chainbase insertion order (duplicate sec keys)
    push_action( "testapi2"_n, "s1secrb"_n,    "testapi2"_n, {} ); // sec rbegin/rend (uint64_t)
    push_action( "testapi2"_n, "s2secrb"_n,    "testapi2"_n, {} ); // sec rbegin/rend (uint128_t)
    push_action( "testapi2"_n, "namepk"_n,     "testapi2"_n, {} ); // name-typed primary key

--- a/tests/toolchain/compile-fail/host_functions_tests.cpp
+++ b/tests/toolchain/compile-fail/host_functions_tests.cpp
@@ -31,9 +31,9 @@ extern "C" __attribute__((sysio_wasm_import)) uint32_t get_blockchain_parameters
 // KV write intrinsics (must be rejected in read-only actions)
 extern "C" __attribute__((sysio_wasm_import)) int64_t kv_set(uint32_t key_format, uint64_t payer, const void* key, uint32_t key_size, const void* value, uint32_t value_size);
 extern "C" __attribute__((sysio_wasm_import)) int64_t kv_erase(uint32_t key_format, const void* key, uint32_t key_size);
-extern "C" __attribute__((sysio_wasm_import)) void kv_idx_store(uint64_t payer, uint32_t table_id, const void* pri_key, uint32_t pri_key_size, const void* sec_key, uint32_t sec_key_size);
-extern "C" __attribute__((sysio_wasm_import)) void kv_idx_remove(uint32_t table_id, const void* pri_key, uint32_t pri_key_size, const void* sec_key, uint32_t sec_key_size);
-extern "C" __attribute__((sysio_wasm_import)) void kv_idx_update(uint64_t payer, uint32_t table_id, const void* pri_key, uint32_t pri_key_size, const void* old_sec_key, uint32_t old_sec_key_size, const void* new_sec_key, uint32_t new_sec_key_size);
+extern "C" __attribute__((sysio_wasm_import)) void kv_idx_store(uint64_t payer, uint32_t table_id, int64_t primary_id, const void* sec_key, uint32_t sec_key_size);
+extern "C" __attribute__((sysio_wasm_import)) void kv_idx_remove(uint32_t table_id, int64_t primary_id, const void* sec_key, uint32_t sec_key_size);
+extern "C" __attribute__((sysio_wasm_import)) void kv_idx_update(uint64_t payer, uint32_t table_id, int64_t primary_id, const void* old_sec_key, uint32_t old_sec_key_size, const void* new_sec_key, uint32_t new_sec_key_size);
 
 extern "C" __attribute__((sysio_wasm_import)) int64_t set_proposed_producers( char*, uint32_t );
 extern "C" __attribute__((sysio_wasm_import)) int64_t set_proposed_producers_ex( uint64_t producer_data_format, char *producer_data, uint32_t producer_data_size );
@@ -101,17 +101,17 @@ public:
    }
    ACTION_TYPE
    bool kvidxstore(){
-      kv_idx_store(0, 0, "p", 1, "s", 1);
+      kv_idx_store(0, 0, 1, "s", 1);
       return true;
    }
    ACTION_TYPE
    bool kvidxremove(){
-      kv_idx_remove(0, "p", 1, "s", 1);
+      kv_idx_remove(0, 1, "s", 1);
       return true;
    }
    ACTION_TYPE
    bool kvidxupdate(){
-      kv_idx_update(0, 0, "p", 1, "s", 1, "t", 1);
+      kv_idx_update(0, 0, 1, "s", 1, "t", 1);
       return true;
    }
    ACTION_TYPE

--- a/tests/unit/test_contracts/capi/db.c
+++ b/tests/unit/test_contracts/capi/db.c
@@ -31,10 +31,10 @@ void test_db( void ) {
    kv_it_value(h, 0, NULL, 0, &actual);
    kv_it_destroy(h);
 
-   // Secondary index operations
-   kv_idx_store(0, 100, "p", 1, "s", 1);
-   kv_idx_update(0, 100, "p", 1, "s", 1, "t", 1);
-   kv_idx_remove(100, "p", 1, "s", 1);
+   // Secondary index operations (primary_id threaded through from kv_set)
+   kv_idx_store(0, 100, 1, "s", 1);
+   kv_idx_update(0, 100, 1, "s", 1, "t", 1);
+   kv_idx_remove(100, 1, "s", 1);
    int32_t sh = kv_idx_find_secondary(0, 100, "s", 1);
    int32_t lb = kv_idx_lower_bound(0, 100, "s", 1);
    (void)lb;

--- a/tests/unit/test_contracts/multi_index_tests.cpp
+++ b/tests/unit/test_contracts/multi_index_tests.cpp
@@ -142,15 +142,20 @@ namespace _test_multi_index
         }
 
         // iterate backward starting with second bob
+        // kv_index_object now uses primary_id (chainbase insertion order) as
+        // the sec-index tiebreaker instead of pri_key bytes. Within the two
+        // bob rows, id=781 was inserted before id=540 (see idx64_store_only
+        // insertion order), so id=781 now sorts before id=540 in the sec
+        // index, reversing the old pri_key-lex ordering.
         {
-            auto pk_itr = table.find(781);
+            auto pk_itr = table.find(540);
             sysio::check(pk_itr != table.end() && pk_itr->sec == "bob"_n.value, "idx64_general - table.find() of existing primary key");
 
             auto itr = secondary_index.iterator_to(*pk_itr);
-            sysio::check(itr->id == 781 && itr->sec == "bob"_n.value, "idx64_general - iterator to existing object in secondary index");
+            sysio::check(itr->id == 540 && itr->sec == "bob"_n.value, "idx64_general - iterator to existing object in secondary index");
 
             --itr;
-            sysio::check(itr != secondary_index.end() && itr->id == 540 && itr->sec == "bob"_n.value, "idx64_general - decrement secondary iterator");
+            sysio::check(itr != secondary_index.end() && itr->id == 781 && itr->sec == "bob"_n.value, "idx64_general - decrement secondary iterator");
 
             --itr;
             sysio::check(itr != secondary_index.end() && itr->id == 650 && itr->sec == "allyson"_n.value, "idx64_general - decrement secondary iterator again");
@@ -160,8 +165,9 @@ namespace _test_multi_index
         }
 
         // iterate backward starting with emily using const_reverse_iterator
+        // Bob's two rows appear in insertion-order: 781 (inserted first) then 540.
         {
-            std::array<uint64_t, 6> pks{{976, 234, 781, 540, 650, 265}};
+            std::array<uint64_t, 6> pks{{976, 234, 540, 781, 650, 265}};
 
             auto pk_itr = pks.begin();
 
@@ -175,14 +181,16 @@ namespace _test_multi_index
             sysio::check(pk_itr == pks.end(), "idx64_general - did not iterate backwards through secondary index properly");
         }
 
-        // require_find secondary key
+        // require_find secondary key.
+        // Under the new primary_id tiebreaker, the first bob in sec order is
+        // id=781 (inserted before id=540); the second is id=540.
         {
             auto itr = secondary_index.require_find("bob"_n.value);
             sysio::check(itr != secondary_index.end(), "idx64_general - require_find must never return end iterator");
-            sysio::check(itr->id == 540, "idx64_general - require_find test");
+            sysio::check(itr->id == 781, "idx64_general - require_find test");
 
             ++itr;
-            sysio::check(itr->id == 781, "idx64_general - require_find secondary key test");
+            sysio::check(itr->id == 540, "idx64_general - require_find secondary key test");
         }
 
         // modify and erase
@@ -522,25 +530,30 @@ public:
         auto table = _test_multi_index::idx64_table<"indextable1"_n.value, "bysecondary"_n.value>( get_self() );
 
         auto sec_index = table.get_index<"bysecondary"_n>();
+        // Under the primary_id tiebreaker, the first bob in sec order is the
+        // row inserted first (id=781).
         auto sk_itr = sec_index.find("bob"_n.value);
-        sysio::check( sk_itr != sec_index.end() && sk_itr->id == 540, "idx64_sk_cache_pk_lookup - sec_index.find() of existing secondary key" );
+        sysio::check( sk_itr != sec_index.end() && sk_itr->id == 781, "idx64_sk_cache_pk_lookup - sec_index.find() of existing secondary key" );
 
         auto pk_itr = table.iterator_to(*sk_itr);
+        // Primary index iteration is by pk (id), so --from(781) on the primary
+        // index lands on 650 (allyson).
         auto prev_itr = --pk_itr;
-        sysio::check( prev_itr->id == 265 && prev_itr->sec == "alice"_n.value, "idx64_sk_cache_pk_lookup - previous record" );
+        sysio::check( prev_itr->id == 650 && prev_itr->sec == "allyson"_n.value, "idx64_sk_cache_pk_lookup - previous record" );
     }
 
     [[sysio::action("s1pkcache")]] void idx64_pk_cache_sk_lookup() {
         auto table = _test_multi_index::idx64_table<"indextable1"_n.value, "bysecondary"_n.value>( get_self() );
 
-
-        auto pk_itr = table.find(540);
+        // bob(id=781) is the first bob in the sec index (inserted before 540);
+        // ++itr across the sec iterator advances to the second bob (id=540).
+        auto pk_itr = table.find(781);
         sysio::check( pk_itr != table.end() && pk_itr->sec == "bob"_n.value, "idx64_pk_cache_sk_lookup - table.find() of existing primary key" );
 
         auto sec_index = table.get_index<"bysecondary"_n>();
         auto sk_itr = sec_index.iterator_to(*pk_itr);
         auto next_itr = ++sk_itr;
-        sysio::check( next_itr->id == 781 && next_itr->sec == "bob"_n.value, "idx64_pk_cache_sk_lookup - next record" );
+        sysio::check( next_itr->id == 540 && next_itr->sec == "bob"_n.value, "idx64_pk_cache_sk_lookup - next record" );
     }
 
     [[sysio::action("s2g")]] void idx128_general() {

--- a/tests/unit/test_contracts/multi_index_tests2.cpp
+++ b/tests/unit/test_contracts/multi_index_tests2.cpp
@@ -264,6 +264,102 @@ public:
         sysio::check(it->id == 20, "clone: original should still be pk 20");
     }
 
+    // ── Composite-key tiebreaker: insertion order within duplicate sec keys ─
+    //
+    // Within rows whose secondary key is equal, iteration order is the order
+    // rows were inserted (their chainbase ids), not primary-key byte-lex. To
+    // tell the two apart this test inserts pk values in non-monotonic order
+    // (40, 10, 30, 20 — all with sec=99), so a pk-lex tiebreaker would yield
+    // (10, 20, 30, 40) while the insertion-order tiebreaker yields the
+    // insertion sequence (40, 10, 30, 20). The test also covers reverse
+    // traversal, erase of a middle duplicate, and modifying a duplicate to
+    // move it out of the group — each verifying the remaining duplicates
+    // keep their original insertion-order positions.
+    [[sysio::action("s1tieb")]] void idx64_sec_tiebreaker() {
+        using namespace _test_multi_index;
+        typedef record_idx64 record;
+
+        sysio::kv_multi_index<"tiebtbl"_n, record,
+            sysio::indexed_by<"bysecondary"_n, sysio::const_mem_fun<record, uint64_t, &record::get_secondary>>
+        > table(get_self(), get_self().value);
+
+        auto payer = get_self();
+
+        // Insert 4 rows with non-monotonic pks, all sharing sec=99.
+        // Insertion order: 40, 10, 30, 20.
+        table.emplace(payer, [](auto& r) { r.id = 40; r.sec = 99; });
+        table.emplace(payer, [](auto& r) { r.id = 10; r.sec = 99; });
+        table.emplace(payer, [](auto& r) { r.id = 30; r.sec = 99; });
+        table.emplace(payer, [](auto& r) { r.id = 20; r.sec = 99; });
+
+        auto idx = table.get_index<"bysecondary"_n>();
+
+        // Forward iteration — must match insertion order, not pk-lex order.
+        {
+            uint64_t expected[] = {40, 10, 30, 20};
+            size_t i = 0;
+            for (auto it = idx.begin(); it != idx.end(); ++it, ++i) {
+                sysio::check(i < 4, "tieb: forward iter ran past end of duplicate group");
+                sysio::check(it->id == expected[i], "tieb: forward iter pk mismatch (expected insertion order)");
+                sysio::check(it->sec == 99, "tieb: forward iter sec mismatch");
+            }
+            sysio::check(i == 4, "tieb: forward iter stopped before end of duplicate group");
+        }
+
+        // Reverse iteration — must be reverse of insertion order.
+        {
+            uint64_t expected[] = {20, 30, 10, 40};
+            size_t i = 0;
+            for (auto rit = idx.rbegin(); rit != idx.rend(); ++rit, ++i) {
+                sysio::check(i < 4, "tieb: reverse iter ran past rend of duplicate group");
+                sysio::check(rit->id == expected[i], "tieb: reverse iter pk mismatch (expected reverse insertion order)");
+            }
+            sysio::check(i == 4, "tieb: reverse iter stopped before rend of duplicate group");
+        }
+
+        // Erase the middle duplicate (pk=30). Remaining insertion order: 40, 10, 20.
+        {
+            auto it = table.find(30);
+            sysio::check(it != table.end(), "tieb: pk=30 must exist before erase");
+            table.erase(it);
+        }
+
+        {
+            uint64_t expected[] = {40, 10, 20};
+            size_t i = 0;
+            for (auto it = idx.begin(); it != idx.end(); ++it, ++i) {
+                sysio::check(i < 3, "tieb: forward iter after erase ran past end");
+                sysio::check(it->id == expected[i], "tieb: forward iter after erase pk mismatch");
+            }
+            sysio::check(i == 3, "tieb: forward iter after erase stopped before end");
+        }
+
+        // Modify pk=10 to change its sec from 99 -> 77. It leaves the sec=99
+        // group; the remaining duplicates (40, 20) must keep their relative order.
+        {
+            auto it = table.find(10);
+            sysio::check(it != table.end(), "tieb: pk=10 must exist before modify");
+            table.modify(it, payer, [](auto& r) { r.sec = 77; });
+        }
+
+        // After the sec change, sec=99 group should be (40, 20).
+        {
+            uint64_t expected[] = {40, 20};
+            size_t i = 0;
+            for (auto it = idx.lower_bound(99); it != idx.end() && it->sec == 99; ++it, ++i) {
+                sysio::check(i < 2, "tieb: sec=99 group has more rows than expected after modify");
+                sysio::check(it->id == expected[i], "tieb: sec=99 group pk mismatch after modify");
+            }
+            sysio::check(i == 2, "tieb: sec=99 group has fewer rows than expected after modify");
+        }
+
+        // pk=10 must be reachable via its new sec_key.
+        {
+            auto it = idx.find(77);
+            sysio::check(it != idx.end() && it->id == 10, "tieb: pk=10 must be findable via sec=77 after modify");
+        }
+    }
+
     // ── Secondary rbegin/rend ───────────────────────────────────────────────
     [[sysio::action("s1secrb")]] void idx64_sec_rbegin() {
         using namespace _test_multi_index;


### PR DESCRIPTION
## Summary

Widens the secondary-index host intrinsics to take `int64_t primary_id` in place of `(pri_key, pri_key_size)`. `kv_set` / `kv_erase` now return the primary row's chainbase id; the CDT wrappers (`kv_multi_index`, `kv_table`) thread that id through each secondary operation.

Requires coordinated wire-sysio change: Wire-Network/wire-sysio#304

## Intrinsic ABI changes

- `kv_set(table_id, payer, key, key_size, value, value_size) -> int64_t` now returns the primary row's chainbase id.
- `kv_erase(table_id, key, key_size) -> int64_t` now returns the deleted primary row's chainbase id.
- `kv_idx_store(payer, table_id, int64_t primary_id, sec_key, sec_key_size)` (replaces `(pri_key, pri_key_size, sec_key, sec_key_size)`).
- `kv_idx_remove(table_id, int64_t primary_id, sec_key, sec_key_size)` (same substitution).
- `kv_idx_update(payer, table_id, int64_t primary_id, old_sec_key, old_sec_key_size, new_sec_key, new_sec_key_size)` (same).
- `kv_it_value(handle, ...)` now accepts secondary iterator handles; resolves the primary's value via the slot's cached `primary_id`.

## CDT wrapper behavior

- `kv_multi_index::emplace` / `put` / `modify` capture the `primary_id` returned from `kv_set` and thread it into each `kv_idx_store` / `kv_idx_update` call.
- `kv_multi_index::erase` reorders: `kv_erase` runs first (returning the `primary_id`), then `kv_idx_remove` for each secondary index with that id. Previously the order was reversed.
- `kv_table::do_insert` / `do_erase` same pattern.
- Secondary iterator value-load path (`kv_table::const_iterator::load_current`) uses `kv_it_value` on the sec handle instead of reconstructing a scoped key and calling `kv_get`. One fewer intrinsic call per iterator advance on read paths.
- `read_primary_key` in `kv_multi_index` strips the scope prefix from the full scoped key returned by `kv_idx_primary_key`.

## Semantic change in sec-index tiebreaker

Within duplicate secondary keys the tiebreaker is now the primary row's chainbase insertion order rather than primary-key byte order. `multi_index_tests.cpp` updated: the two "bob" rows in the idx64 test now iterate in insertion order (id=781 before id=540) rather than pri_key-lex order (540 before 781).

## Refactors

- `libraries/sysiolib/contracts/sysio/detail/kv_idx_intrinsics.hpp` — new internal header holding the 10 secondary-index `extern "C"` declarations. `kv_multi_index.hpp` and `kv_table.hpp` now include it instead of duplicating the block. Signature changes only need to touch one place.

## Docs

- `docs/kv-intrinsics-reference.md` — updated return-value semantics for `kv_set` / `kv_erase` and new signatures for the `kv_idx_*` family.
- `docs/kv-scoped-table.md` — describes the sec-row layout under the primary_id scheme.