### PR TITLE
Kv: kv_multi_index cleanups and primary-key guidance docs

### DIFF
--- a/docs/kv-storage-guide.md
+++ b/docs/kv-storage-guide.md
@@ -97,6 +97,57 @@ Note: the chain enforces a separate maximum key size (`max_kv_key_size`, default
 [name:8B BE] = 8 bytes
 ```
 
+## Choosing a Primary Key When Using Secondary Indexes
+
+Every secondary-index row stores a copy of the primary key bytes as a reference back to the primary row. The smaller the primary key, the cheaper each secondary row.
+
+**Default rule:** the primary key should be the smallest unique identifier for the row. For most tables that means a `uint64`.
+
+### Picking the primary
+
+**Have a uint64 natural unique identifier already (name, id, etc.)?**
+
+Use it. Add secondaries for the other lookups you need.
+
+**Have only larger natural unique candidates (strings, composites)?**
+
+You can either keep the natural field as the primary or switch to a `uint64` surrogate and demote the natural field to a secondary.
+
+Switching to a surrogate has two effects per primary row:
+
+- **It saves** `(natural_size - 8)` bytes on every secondary row, because secondaries now point at an 8-byte surrogate instead of the full natural key.
+- **It costs** about 128 bytes for the one extra secondary you now need (to look up by the natural field that used to be the primary).
+
+The surrogate becomes the cheaper layout once the per-row savings on the existing secondaries outweigh the cost of the one added secondary. Concrete break-even points:
+
+| Number of lookup paths total | Natural primary stays cheaper if its size is at most |
+|---|---|
+| 2 | ~136 B |
+| 3 | ~72 B |
+| 4 | ~50 B |
+| 5 | ~40 B |
+| 10 | ~22 B |
+| 20+ | always switch to surrogate |
+
+When in doubt, go with the surrogate - it is harder to be surprised by future growth (each new secondary makes the surrogate relatively cheaper).
+
+**Have no natural unique identifier at all (log, queue, append-only)?**
+
+Introduce a surrogate `uint64` - a sequence counter, hash-truncated id, or auto-incrementing identifier. It is the smallest possible primary, guarantees uniqueness, future-proofs against later secondaries, and gives you a stable handle for cross-table references.
+
+Do **not** pick an arbitrary larger field "because it's there." The primary key is duplicated onto every secondary row, so picking a 30 B field with no query reason costs you 30 bytes per (row * sec index) plus the field on the primary itself.
+
+### Scaling
+
+Extra RAM versus the 8 B uint64 baseline grows linearly in row count, secondary index count, and primary key size. At 1M rows with 3 secondary indexes:
+
+| `pri_key_size` | Extra sec RAM |
+|----------------|---------------|
+| 8 B (uint64) | baseline |
+| 32 B | ~72 MB |
+| 64 B | ~168 MB |
+| 128 B | ~360 MB |
+
 ## Zero-Copy Serialization
 
 When `V` is `trivially_copyable` and `sizeof(V) == pack_size(V)`, the value is stored and retrieved via direct `memcpy` — no datastream encoding. This eliminates serialization overhead for POD structs:

--- a/libraries/sysiolib/contracts/sysio/detail/kv_idx_intrinsics.hpp
+++ b/libraries/sysiolib/contracts/sysio/detail/kv_idx_intrinsics.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+// Secondary-index host intrinsics shared by kv_multi_index.hpp and
+// kv_table.hpp. Consolidated here so signature changes only need to
+// touch one place; both wrappers transitively reach these through
+// their own includes.
+//
+// Primary KV and primary-iterator intrinsics (kv_set/kv_get/kv_erase/
+// kv_contains, kv_it_*) are declared in <sysio/kv_utils.hpp>.
+
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+
+__attribute__((sysio_wasm_import))
+void kv_idx_store(uint64_t payer, uint32_t table_id,
+                  const void* pri_key, uint32_t pri_key_size,
+                  const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+void kv_idx_remove(uint32_t table_id,
+                   const void* pri_key, uint32_t pri_key_size,
+                   const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+void kv_idx_update(uint64_t payer, uint32_t table_id,
+                   const void* pri_key, uint32_t pri_key_size,
+                   const void* old_sec_key, uint32_t old_sec_key_size,
+                   const void* new_sec_key, uint32_t new_sec_key_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_find_secondary(uint64_t code, uint32_t table_id,
+                              const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_lower_bound(uint64_t code, uint32_t table_id,
+                           const void* sec_key, uint32_t sec_key_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_next(uint32_t handle);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_prev(uint32_t handle);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_key(uint32_t handle, uint32_t offset,
+                   void* dest, uint32_t dest_size, uint32_t* actual_size);
+
+__attribute__((sysio_wasm_import))
+int32_t kv_idx_primary_key(uint32_t handle, uint32_t offset,
+                           void* dest, uint32_t dest_size, uint32_t* actual_size);
+
+__attribute__((sysio_wasm_import))
+void kv_idx_destroy(uint32_t handle);
+
+} // extern "C"

--- a/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_multi_index.hpp
@@ -14,64 +14,8 @@
  */
 
 #include <cstdint>
-#include <sysio/kv_utils.hpp>
-
-// KV intrinsic declarations (primary + secondary — multi_index uses both)
-extern "C" {
-   __attribute__((sysio_wasm_import))
-   int64_t kv_set(uint32_t table_id, uint64_t payer, const void* key, uint32_t key_size, const void* value, uint32_t value_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_get(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size, void* value, uint32_t value_size);
-   __attribute__((sysio_wasm_import))
-   int64_t kv_erase(uint32_t table_id, const void* key, uint32_t key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_contains(uint32_t table_id, uint64_t code, const void* key, uint32_t key_size);
-   __attribute__((sysio_wasm_import))
-   uint32_t kv_it_create(uint32_t table_id, uint64_t code, const void* prefix, uint32_t prefix_size);
-   __attribute__((sysio_wasm_import))
-   void kv_it_destroy(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_status(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_next(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_prev(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_lower_bound(uint32_t handle, const void* key, uint32_t key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_it_value(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_store(uint64_t payer, uint32_t table_id,
-                     const void* pri_key, uint32_t pri_key_size,
-                     const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_remove(uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
-                      const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_update(uint64_t payer, uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
-                      const void* old_sec_key, uint32_t old_sec_key_size,
-                      const void* new_sec_key, uint32_t new_sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_find_secondary(uint64_t code, uint32_t table_id,
-                                 const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_lower_bound(uint64_t code, uint32_t table_id,
-                              const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_next(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_prev(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_primary_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_destroy(uint32_t handle);
-}
+#include <sysio/kv_utils.hpp>                   // primary KV + iterator intrinsics
+#include <sysio/detail/kv_idx_intrinsics.hpp>   // secondary-index intrinsics
 
 #include <sysio/name.hpp>
 #include <sysio/serialize.hpp>
@@ -201,6 +145,8 @@ namespace _kv_multi_index_detail {
 template<name::raw TableName, typename T, typename... Indices>
 class kv_multi_index {
    static_assert(sizeof...(Indices) <= 16, "multi_index supports at most 16 secondary indices");
+   static_assert(std::is_default_constructible_v<T>,
+                 "kv_multi_index row type must be default-constructible; add a default ctor to T");
 
    /// table_id computed at compile time from the template parameter.
    static constexpr uint32_t _table_id = sysio::kv::compute_table_id(static_cast<uint64_t>(TableName));
@@ -299,10 +245,9 @@ class kv_multi_index {
       if (sz <= static_cast<int32_t>(sysio::kv::kv_value_stack_size)) {
          obj = deserialize_row(stack, sz);
       } else {
-         char* heap = new char[sz];
-         ::kv_get(_table_id, _code.value, key.data, key_size, heap, sz);
-         obj = deserialize_row(heap, sz);
-         delete[] heap;
+         sysio::kv::ser_buf heap_buf(static_cast<uint32_t>(sz));
+         ::kv_get(_table_id, _code.value, key.data, key_size, heap_buf.data(), sz);
+         obj = deserialize_row(heap_buf.data(), sz);
       }
 
       auto ptr = std::make_unique<T>(std::move(obj));

--- a/libraries/sysiolib/contracts/sysio/kv_table.hpp
+++ b/libraries/sysiolib/contracts/sysio/kv_table.hpp
@@ -29,7 +29,8 @@
  *   auto it  = idx.find("alice"_n);
  */
 
-#include <sysio/kv_utils.hpp>
+#include <sysio/kv_utils.hpp>                   // primary KV + iterator intrinsics
+#include <sysio/detail/kv_idx_intrinsics.hpp>   // secondary-index intrinsics
 #include <sysio/check.hpp>
 
 #include <cstring>
@@ -37,41 +38,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-// Secondary index intrinsic declarations (not in kv_utils.hpp).
-// Duplicate extern "C" declarations are harmless if kv_multi_index.hpp
-// is also included.
-extern "C" {
-   __attribute__((sysio_wasm_import))
-   void kv_idx_store(uint64_t payer, uint32_t table_id,
-                     const void* pri_key, uint32_t pri_key_size,
-                     const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_remove(uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
-                      const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_update(uint64_t payer, uint32_t table_id,
-                      const void* pri_key, uint32_t pri_key_size,
-                      const void* old_sec_key, uint32_t old_sec_key_size,
-                      const void* new_sec_key, uint32_t new_sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_find_secondary(uint64_t code, uint32_t table_id,
-                                 const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_lower_bound(uint64_t code, uint32_t table_id,
-                              const void* sec_key, uint32_t sec_key_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_next(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_prev(uint32_t handle);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   int32_t kv_idx_primary_key(uint32_t handle, uint32_t offset, void* dest, uint32_t dest_size, uint32_t* actual_size);
-   __attribute__((sysio_wasm_import))
-   void kv_idx_destroy(uint32_t handle);
-}
 
 namespace sysio { namespace kv {
 


### PR DESCRIPTION
## Summary

Three independent cleanups in `kv_multi_index.hpp` / `kv_table.hpp` lifted from a discarded feature branch, plus a new docs section on primary-key sizing.

- `detail/kv_idx_intrinsics.hpp`: new internal header holding the 10 secondary-index `extern "C"` declarations. Both `kv_multi_index.hpp` and `kv_table.hpp` now include it instead of duplicating the block.
- Drop the duplicate `kv_set`/`kv_get`/`kv_erase`/`kv_contains`/`kv_it_*` `extern` block from `kv_multi_index.hpp` - `kv_utils.hpp` already declares those.
- Add class-level `static_assert(std::is_default_constructible_v<T>)` to `kv_multi_index` so non-default-constructible row types fail at the class declaration instead of deep inside `load_object`.
- `kv_multi_index::load_object` heap fallback now uses `sysio::kv::ser_buf` (RAII) instead of raw `new[]/delete[]`.
- `docs/kv-storage-guide.md`: new section documenting when to use a natural primary key versus a `uint64` surrogate. Secondary rows store a copy of the primary key bytes per index, so long primary keys multiply RAM cost across all secondaries.