### PR TITLE
Update checkout action to Node 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-24.04
     container: ${{fromJSON(needs.discover.outputs.p)[matrix.platform].image}}
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v5
           with:
             submodules: recursive
         - name: Cache ccache


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from `@v3` to `@v5` in the Build & Test workflow.

## Why this is necessary
The latest `master` workflow run emitted a GitHub Actions warning that `actions/checkout@v3` is still running on the Node.js 20 action runtime. GitHub will force JavaScript actions to Node.js 24 by default starting June 2, 2026 and remove Node.js 20 from runners on September 16, 2026.

`actions/checkout@v5` declares `runs.using: node24`, so this removes the remaining Node.js 20 runtime warning from the checkout step.

## Validation
- Confirmed `actions/checkout@v5` action metadata declares `runs.using: node24`.
- Parsed `.github/workflows/build.yaml` with PyYAML.
- `git diff --check`