### PR TITLE
Pin vcpkg default registry reference

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,6 +3,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "74e6536215718009aae747d86d84b78376bf9e09",
+    "reference": "bc71aa640f89933294f16e004b212c7fd3183eed",
     "repository": "https://github.com/Microsoft/vcpkg"
   }
 }


### PR DESCRIPTION
## Summary

- Pin the Microsoft vcpkg default registry `reference` to `bc71aa640f89933294f16e004b212c7fd3183eed`

## Why

`baseline` anchors package versions, while `reference` controls which Git ref vcpkg uses to read the registry version database. Without an explicit `reference`, vcpkg can consult the moving registry `HEAD` when resolving available versions.

This uses the same Microsoft/vcpkg reference selected for `wire-sysio`. It contains the current `wire-cdt` manifest overrides, including:

- `protobuf 6.33.4#1`
- `llvm 18.1.6#5`

## Verification

- `jq empty vcpkg-configuration.json`
- Verified the pinned Microsoft/vcpkg commit contains version database entries for `protobuf 6.33.4#1` and `llvm 18.1.6#5`
- Ran `vcpkg install --dry-run --triplet x64-linux --host-triplet x64-linux` from a temporary manifest root; dependency resolution succeeded against the pinned registry reference
