### PR TITLE
crypto: add recover_key_nothrow intrinsic + CDT bindings

### DIFF
--- a/imports/cdt.imports.in
+++ b/imports/cdt.imports.in
@@ -124,6 +124,7 @@ publication_time
 read_action_data
 read_transaction
 recover_key
+recover_key_nothrow
 remove_security_group_participants
 require_auth
 require_auth2

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -58,6 +58,9 @@ extern "C" {
    int recover_key( const capi_checksum256* digest, const char* sig, size_t siglen, char* pub, size_t publen ) {
       return intrinsics::get().call<intrinsics::recover_key>(digest, sig, siglen, pub, publen);
    }
+   int recover_key_nothrow( const capi_checksum256* digest, const char* sig, size_t siglen, char* pub, size_t publen ) {
+      return intrinsics::get().call<intrinsics::recover_key_nothrow>(digest, sig, siglen, pub, publen);
+   }
    void assert_sha256( const char* data, uint32_t length, const capi_checksum256* hash ) {
       return intrinsics::get().call<intrinsics::assert_sha256>(data, length, hash);
    }

--- a/libraries/native/native/sysio/intrinsics_def.hpp
+++ b/libraries/native/native/sysio/intrinsics_def.hpp
@@ -59,6 +59,7 @@ intrinsic_macro(preactivate_feature) \
 intrinsic_macro(get_active_producers) \
 intrinsic_macro(assert_recover_key) \
 intrinsic_macro(recover_key) \
+intrinsic_macro(recover_key_nothrow) \
 intrinsic_macro(assert_sha256) \
 intrinsic_macro(assert_sha1) \
 intrinsic_macro(assert_sha512) \

--- a/libraries/sysiolib/capi/sysio/crypto.h
+++ b/libraries/sysiolib/capi/sysio/crypto.h
@@ -205,6 +205,32 @@ __attribute__((sysio_wasm_import))
 int recover_key( const struct capi_checksum256* digest, const char* sig, size_t siglen, char* pub, size_t publen );
 
 /**
+ *  Non-throwing variant of `recover_key`. Catches every exception the
+ *  host crypto path can raise (malformed signature bytes, unactivated
+ *  signature type, recovery math failure, subjective-size limit, etc.)
+ *  and returns -1 instead of halting the contract. On success returns
+ *  the same byte count as `recover_key`.
+ *
+ *  CDT contracts compile with `-fno-exceptions`, so a throwing
+ *  intrinsic call from inside a contract halts dispatch — there is no
+ *  try/catch around it. Inbound-attestation handlers
+ *  (`feedback_opp_handlers_never_throw.md`) MUST NOT halt; they need
+ *  this nothrow variant when verifying attacker-controlled signature
+ *  bytes (e.g. the underwriter race resolver in `sysio.uwrit`).
+ *
+ *  @param digest - Pre-hashed message to recover against
+ *  @param sig    - Packed signature bytes (sysio::signature wire format)
+ *  @param siglen - Signature byte count
+ *  @param pub    - Destination buffer for the recovered packed public key
+ *  @param publen - Capacity of `pub` in bytes
+ *
+ *  @return Bytes written to `pub` on success; -1 on any host-side error
+ *          (no exception escapes the call).
+ */
+__attribute__((sysio_wasm_import))
+int recover_key_nothrow( const struct capi_checksum256* digest, const char* sig, size_t siglen, char* pub, size_t publen );
+
+/**
  *  Tests a given public key with the generated key from digest and the signature.
  *
  *  @param digest - What the key will be generated from

--- a/libraries/sysiolib/core/sysio/crypto.hpp
+++ b/libraries/sysiolib/core/sysio/crypto.hpp
@@ -9,6 +9,7 @@
 #include "serialize.hpp"
 
 #include <array>
+#include <optional>
 
 namespace sysio {
 
@@ -452,6 +453,24 @@ namespace sysio {
     *  @return sysio::public_key - Recovered public key
     */
    sysio::public_key recover_key( const sysio::checksum256& digest, const sysio::signature& sig );
+
+   /**
+    *  Non-throwing variant of `recover_key`. Returns the recovered key on
+    *  success, `std::nullopt` if the host caught any exception (malformed
+    *  signature bytes, unactivated signature type, recovery math failure,
+    *  subjective-size limit, etc.). Use this from CDT contracts that MUST
+    *  NOT halt on attacker-controlled signature bytes — see
+    *  `feedback_opp_handlers_never_throw.md`. CDT compiles with
+    *  `-fno-exceptions` so the throwing variant cannot be wrapped in
+    *  contract-side `try/catch`; the host-side wrapper catches instead.
+    *
+    *  @ingroup crypto
+    *  @param digest - Digest of the message that was signed
+    *  @param sig - Signature
+    *  @return Recovered public key, or `std::nullopt` on any failure.
+    */
+   std::optional<sysio::public_key> recover_key_nothrow( const sysio::checksum256& digest,
+                                                          const sysio::signature& sig );
 
    /**
     *  Tests a given public key with the recovered public key from digest and signature.

--- a/libraries/sysiolib/crypto.cpp
+++ b/libraries/sysiolib/crypto.cpp
@@ -40,6 +40,10 @@ extern "C" {
                     size_t siglen, char* pub, size_t publen );
 
    __attribute__((sysio_wasm_import))
+   int recover_key_nothrow( const capi_checksum256* digest, const char* sig,
+                            size_t siglen, char* pub, size_t publen );
+
+   __attribute__((sysio_wasm_import))
    void assert_recover_key( const capi_checksum256* digest, const char* sig,
                             size_t siglen, const char* pub, size_t publen );
 }
@@ -117,6 +121,46 @@ namespace sysio {
          if( max_stack_buffer_size < pubkey_size ) {
             free(pubkey_data);
          }
+      }
+      return pubkey;
+   }
+
+   std::optional<sysio::public_key> recover_key_nothrow( const sysio::checksum256& digest,
+                                                         const sysio::signature& sig ) {
+      auto digest_data = digest.extract_as_byte_array();
+      auto sig_data    = sysio::pack(sig);
+
+      char optimistic_pubkey_data[256];
+      int rc = ::recover_key_nothrow(
+         reinterpret_cast<const capi_checksum256*>(digest_data.data()),
+         sig_data.data(), sig_data.size(),
+         optimistic_pubkey_data, sizeof(optimistic_pubkey_data) );
+      if ( rc < 0 ) return std::nullopt;
+
+      const size_t pubkey_size = static_cast<size_t>(rc);
+      sysio::public_key pubkey;
+      if ( pubkey_size <= sizeof(optimistic_pubkey_data) ) {
+         sysio::datastream<const char*> pubkey_ds( optimistic_pubkey_data, pubkey_size );
+         pubkey_ds >> pubkey;
+      } else {
+         constexpr static size_t max_stack_buffer_size = 512;
+         void* pubkey_data = (max_stack_buffer_size < pubkey_size)
+                              ? malloc(pubkey_size)
+                              : alloca(pubkey_size);
+
+         int rc2 = ::recover_key_nothrow(
+            reinterpret_cast<const capi_checksum256*>(digest_data.data()),
+            sig_data.data(), sig_data.size(),
+            reinterpret_cast<char*>(pubkey_data), pubkey_size );
+         if ( rc2 < 0 ) {
+            if ( max_stack_buffer_size < pubkey_size ) free(pubkey_data);
+            return std::nullopt;
+         }
+         sysio::datastream<const char*> pubkey_ds(
+            reinterpret_cast<const char*>(pubkey_data), pubkey_size );
+         pubkey_ds >> pubkey;
+
+         if ( max_stack_buffer_size < pubkey_size ) free(pubkey_data);
       }
       return pubkey;
    }


### PR DESCRIPTION
## Summary

- Adds a `recover_key_nothrow` intrinsic and CDT binding alongside the existing `recover_key`. Returns `-1` (C-API) / `std::nullopt` (C++ wrapper) instead of throwing on any host-side failure (malformed signature bytes, unactivated signature type, recovery math failure, subjective-size limit).
- CDT contracts compile with `-fno-exceptions`, so the throwing `recover_key` halts the WASM on attacker-controlled signature bytes — fatal inside any handler that runs in the `evalcons` inline-action chain (e.g. `sysio.uwrit::try_select_winner`), where a halt stalls consensus.
- Wired through `imports/cdt.imports.in`, `libraries/sysiolib/capi/sysio/crypto.h`, `libraries/sysiolib/crypto.cpp`, `libraries/sysiolib/core/sysio/crypto.hpp`, plus the native-shim entries in `libraries/native/intrinsics.cpp` and `intrinsics_def.hpp` so test contracts on the native runtime resolve the symbol.

The matching host-side `try/catch` wrapper around `recover_key` lives in `wire-sysio`. Consumed at the depot by `sysio.uwrit::verify_uic_signature` on the underwriter race path.

## Test plan

- [ ] Build CDT (`cmake --build build`) and confirm the new intrinsic links.
- [ ] Rebuild any contract that adopts `recover_key_nothrow` (e.g. `sysio.uwrit`) and verify it imports `recover_key_nothrow` in the resulting WASM.
- [ ] On the native runtime, exercise a contract that calls `recover_key_nothrow` with both a valid signature and an intentionally malformed one; expect a recovered key in the first case and `std::nullopt` (no halt) in the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)