### PR TITLE
Fix skipped status in build notifications

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,5 +116,5 @@ jobs:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           notification-type: 1
           workflow-name: "CDT Build & Test"
-          job-results: "discover:${{ needs.discover.result }} build-platforms:${{ needs.build-platforms.result }} build:${{ needs.build.result }}"
+          job-results: "discover:${{ needs.discover.result }} build-platforms:${{ needs.build-platforms.result == 'skipped' && 'success' || needs.build-platforms.result }} build:${{ needs.build.result }}"
           github-context: ${{ toJSON(github) }}


### PR DESCRIPTION
## Why

The Build Platforms job is optional and is expected to be skipped whenever the required builder image already exists. After PR #58, the notification action receives `build-platforms:skipped` along with successful discover/build jobs and reports the whole workflow notification as SKIPPED even though the workflow itself passed.

## Summary

- normalize `build-platforms:skipped` to `success` only in the notification payload
- preserve real `failure` and `cancelled` results from the Build Platforms job

## Validation

- inspected run `26117752616` for commit `0ea07e6`, where the workflow concluded success but the notification action reported SKIPPED because `job-results` included `build-platforms:skipped`
- ran `git diff --check`
