### PR TITLE
cmake: link magic_enum into add_native_contract targets

### DIFF
--- a/cmake/CDTMacros.cmake.in
+++ b/cmake/CDTMacros.cmake.in
@@ -241,6 +241,12 @@ function(add_native_contract)
     "${CDT_ROOT}/include"
   )
 
+  # OPP-generated protobuf headers (types.pb.hpp) depend on magic_enum. The
+  # imported target name is identical in the CDT and consumer vcpkg trees, so
+  # linking it resolves the header for the host compiler.
+  find_cdt_magic_enum()
+  target_link_libraries(${ARG_TARGET} PRIVATE magic_enum::magic_enum)
+
   # Compile definitions for native mode
   target_compile_definitions(${ARG_TARGET} PRIVATE
     __sysio_cdt_native__


### PR DESCRIPTION
## Summary

`add_native_contract()` compiles contract sources with the host compiler into a dlopen-able `.so` for the native-module runtime. It sets up the CDT include paths but never provided `magic_enum`.

Wire's OPP system contracts include generated protobuf headers (`types.pb.hpp`) that depend on `magic_enum`, so native builds of those contracts fail to find `<magic_enum/magic_enum.hpp>`.

This calls `find_cdt_magic_enum()` and links `magic_enum::magic_enum` into native contract targets. The imported target name is identical in the CDT and consumer (wire-sysio) vcpkg trees, so the host compiler resolves the header either way.

## Context

This is the CDT-side half of the fix for the Wire-Network/wire-sysio#281 review feedback. The wire-sysio side reverts a per-contract `-I` workaround that had been masking this gap; the proper fix belongs here in the native-contract template.