### PR TITLE
Restore vcpkg registry configuration

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,6 @@
   "default-registry": {
     "kind": "git",
     "baseline": "74e6536215718009aae747d86d84b78376bf9e09",
-    "reference": "bc71aa640f89933294f16e004b212c7fd3183eed",
     "repository": "https://github.com/Microsoft/vcpkg"
   }
 }


### PR DESCRIPTION
## Summary
- restore `vcpkg-configuration.json` to the state from `c58595bb`
- remove the later default-registry `reference` pin while keeping the baseline and no custom registries

## Validation
- `python3 -m json.tool vcpkg-configuration.json`
- `git diff --exit-code c58595bb -- vcpkg-configuration.json`