### PR TITLE
Resolve staged LLVM tool symlinks

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -82,12 +82,17 @@ foreach(target clang clang++ wasm-ld llvm-ar llvm-ranlib llvm-nm llvm-objcopy ll
    unset(_tool_path CACHE)
    find_program(_tool_path ${target} HINTS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
    if(_tool_path)
-      if(IS_SYMLINK ${CMAKE_BINARY_DIR}/bin/${target})
-         file(REMOVE ${CMAKE_BINARY_DIR}/bin/${target})
+      get_filename_component(_real_tool_path "${_tool_path}" REALPATH)
+      set(_staged_tool_path "${CMAKE_BINARY_DIR}/bin/${target}")
+      if(EXISTS "${_staged_tool_path}" OR IS_SYMLINK "${_staged_tool_path}")
+         file(REMOVE "${_staged_tool_path}")
       endif()
-      file(COPY ${_tool_path}
-         DESTINATION ${CMAKE_BINARY_DIR}/bin
-         FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+      execute_process(
+         COMMAND ${CMAKE_COMMAND} -E copy "${_real_tool_path}" "${_staged_tool_path}"
+         RESULT_VARIABLE _copy_result)
+      if(NOT _copy_result EQUAL 0)
+         message(FATAL_ERROR "Failed to stage LLVM tool '${target}' from '${_real_tool_path}' to '${_staged_tool_path}'")
+      endif()
    else()
       message(WARNING "LLVM tool '${target}' not found in ${LLVM_TOOLS_BINARY_DIR}")
    endif()


### PR DESCRIPTION
## Background
While investigating the stale build/vcpkg failure, we found a concrete staging bug independent of the vcpkg manifest fingerprint discussion.

vcpkg stages some LLVM tools as symlinks. In particular, `clang` and `clang++` can be symlinks to versioned binaries such as `clang-18`. The CDT tools build copied those symlinks into `tools/bin`, and the top-level build then copied from `tools/bin` into the final build `bin` directory. In a stale or partially refreshed build tree, this could leave `build/.../bin/clang` missing or unusable even though `cdt-cc` expects to launch a program named `clang`.

That failure mode was especially confusing because `CDTWasmLibraries` would fail while compiling many libc sources through `cdt-cc`, making the root cause look like a broad compile failure instead of a missing delegated compiler binary.

## Change
This PR is now intentionally limited to the real symlink staging bug:
- resolve each LLVM tool path to its real executable before staging it
- remove any existing staged file or symlink for that tool name
- copy the resolved executable to the expected tool name in `tools/bin`
- fail CMake configure with a clear error if staging the tool fails

This keeps `clang`, `clang++`, `wasm-ld`, and the other staged LLVM tools available under the names that CDT wrappers expect to execute.

## What Changed From The Earlier Version
The vcpkg manifest fingerprint workaround was removed from this PR. The reviewer feedback was right: the fingerprint treated a symptom of using `ExternalProject_Add` for host-side tools. A cleaner follow-up is to lift `CDTTools` and `toolchain-tester` into the parent build with `add_subdirectory`, while keeping `CDTWasmLibraries` external because it uses the just-built wasm CDT toolchain.

## Verification
- trimmed the PR branch to contain only the symlink staging fix on top of latest `origin/develop`
- confirmed the diff is limited to `tools/CMakeLists.txt`
- confirmed no `CDT_VCPKG_MANIFEST_FINGERPRINT` changes remain in this PR
- earlier stale-tree verification showed that, after this staging fix, `CDTWasmLibraries` completes and `build/stale-test/bin/clang --version` / `build/stale-test/bin/cdt-cc -v` report clang `18.1.6`
