### PR TITLE
Report CDT subprogram launch failures

### DIFF
--- a/tools/cc/cdt-cc.cpp.in
+++ b/tools/cc/cdt-cc.cpp.in
@@ -22,8 +22,7 @@ int main(int argc, const char **argv) {
    // fix to show version info without having to have any other arguments
    for (int i=0; i < argc; i++) {
      if (argv[i] == std::string("-v")) {
-       sysio::cdt::environment::exec_subprogram("clang", {"-v"});
-       return 0;
+       return sysio::cdt::environment::exec_subprogram("clang", {"-v"}) ? 0 : -1;
      }
    }
 

--- a/tools/cc/cdt-cpp.cpp.in
+++ b/tools/cc/cdt-cpp.cpp.in
@@ -28,8 +28,7 @@ int main(int argc, const char **argv) {
    // fix to show version info without having to have any other arguments
    for (int i=0; i < argc; i++) {
      if (argv[i] == std::string("-v")) {
-       sysio::cdt::environment::exec_subprogram("clang++", {"-v"});
-       return 0;
+       return sysio::cdt::environment::exec_subprogram("clang++", {"-v"}) ? 0 : -1;
      }
    }
 

--- a/tools/include/sysio/utils.hpp
+++ b/tools/include/sysio/utils.hpp
@@ -14,6 +14,7 @@ extern char **environ;
 #endif
 
 #include "whereami/whereami.hpp"
+#include <iostream>
 #include <vector>
 #include <sstream>
 
@@ -153,10 +154,26 @@ struct environment {
             redirects[1] = llvm::StringRef{*stdout_file};
          if(stderr_file)
             redirects[2] = llvm::StringRef{*stderr_file};
-         return llvm::sys::ExecuteAndWait(*path, args, std::nullopt, redirects, 0, 0, nullptr, nullptr) == 0;
+         std::string err_msg;
+         bool execution_failed = false;
+         int result = llvm::sys::ExecuteAndWait(*path, args, std::nullopt, redirects, 0, 0, &err_msg, &execution_failed);
+         if (execution_failed || result < 0) {
+            std::cerr << "cdt: failed to execute subprogram '" << prog << "' at '" << *path << "'";
+            if (!err_msg.empty()) {
+               std::cerr << ": " << err_msg;
+            } else if (result == -1) {
+               std::cerr << ": unable to execute";
+            } else if (result == -2) {
+               std::cerr << ": process crashed or timed out";
+            }
+            std::cerr << std::endl;
+         }
+         return result == 0;
       }
-      else
+      else {
+         std::cerr << "cdt: failed to find subprogram '" << prog << "' in '" << find_path << "'" << std::endl;
          return false;
+      }
       return true;
    }
 


### PR DESCRIPTION
## Background
When `cdt-cc`, `cdt-cpp`, or another CDT frontend delegates to a subprogram such as `clang`, `clang++`, `cdt-ld`, or `wasm-ld`, failures from launching that subprogram are currently too easy to miss.

This showed up while investigating the stale vcpkg/LLVM build issue: `CDTWasmLibraries` failed almost immediately while compiling libc sources through `build/.../bin/cdt-cc`, but the build log only showed many compile commands failing. The real problem was that `cdt-cc` could not launch the expected `clang` binary from the CDT `bin` directory, and `exec_subprogram` returned `false` without printing the program it tried, the resolved path, or why execution failed.

That makes the first actionable error disappear behind hundreds of downstream Ninja failures. A missing binary, broken symlink, bad permissions, or crashed delegated tool all look roughly the same from the top-level build output.

## Resolution
This PR makes delegated tool failures explicit:
- `exec_subprogram` now reports when it cannot find the requested subprogram in the CDT tool directory
- if LLVM finds the program but `ExecuteAndWait` cannot launch it, the error includes both the logical program name and resolved path
- any LLVM-provided execution error message is printed when available
- `cdt-cc -v` and `cdt-cpp -v` now return failure when delegated `clang -v` / `clang++ -v` fails, instead of always returning success

With this in place, the next failure mode like this should point directly at the missing or unlaunchable tool instead of only showing generic compile-step failures.

## Example Failure Made Clearer
Before this change, a missing `clang` during `CDTWasmLibraries` could look like repeated failed compile lines from `cdt-cc` with no underlying cause.

After this change, the log should include a message like:

```text
cdt: failed to find subprogram 'clang' in '/path/to/build/bin'\n```\n\nor, when the binary is found but cannot be executed:\n\n```text\ncdt: failed to execute subprogram 'clang' at '/path/to/build/bin/clang': <system error>\n```\n\n## Verification\n- inspected the diff against `origin/develop`\n- confirmed this PR is intentionally limited to diagnostics and exit status handling\n- the stale-tree functional fix is separate in PR #69 (`feature/vcpkg-manifest-fingerprint`)\n