### PR TITLE
Run build workflow for PRs to develop

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: 
       - master
+      - develop
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Background
The Build & Test GitHub Actions workflow currently runs for pull requests targeting `master`, but not for pull requests targeting `develop`.

Now that active work is being proposed against `develop`, PRs such as feature branches merging into `develop` can be opened without automatically running the main build/test workflow. That means regressions may only be caught later when changes move toward `master`.

## Change
- add `develop` to the `pull_request.branches` filter in `.github/workflows/build.yaml`
- keep the existing `master` PR trigger unchanged
- leave push triggers unchanged (`master` and `release/*`)

## Expected Result
Pull requests with base branch `develop` will trigger the same Build & Test workflow that already runs for pull requests to `master`.

## Verification
- checked the workflow trigger filter locally
- this PR itself targets `develop`, so it should exercise the new path once GitHub evaluates the workflow changes
