### PR TITLE
Parse sysio ISO time strings as UTC

### DIFF
--- a/libraries/sysiolib/core/sysio/time.hpp
+++ b/libraries/sysiolib/core/sysio/time.hpp
@@ -8,6 +8,16 @@
 #include "serialize.hpp"
 
 namespace sysio {
+  namespace detail {
+     inline std::time_t timegm(std::tm* tm) {
+  #ifdef _WIN32
+        return ::_mkgmtime(tm);
+  #else
+        return ::timegm(tm);
+  #endif
+     }
+  }
+
   /**
    *  @defgroup time
    *  @ingroup core
@@ -62,10 +72,10 @@ namespace sysio {
         uint32_t            sec_since_epoch()const  { return uint32_t(elapsed.count() / 1000000); }
 
         static time_point from_iso_string(const std::string& date_str) {
-           std::tm tm;
+           std::tm tm = {};
            check(strptime(date_str.c_str(), "%Y-%m-%dT%H:%M:%S", &tm), "date parsing failed");
 
-           auto tp = std::chrono::system_clock::from_time_t( ::mktime( &tm ) );
+           auto tp = std::chrono::system_clock::from_time_t( detail::timegm( &tm ) );
            auto duration = std::chrono::duration_cast<std::chrono::microseconds>( tp.time_since_epoch() );
            return time_point{ microseconds{ static_cast<int64_t>(duration.count()) } };
         }


### PR DESCRIPTION
## Change Description
Fix `sysio::time_point::from_iso_string` so ISO timestamp strings are interpreted as UTC instead of local time.

The previous implementation parsed the timestamp with `strptime` and then converted it with `mktime`, which treats the `std::tm` as local time. That makes `from_iso_string("1970-01-01T00:00:00")` timezone-dependent on host platforms. The new implementation zero-initializes `std::tm` and converts with a small UTC helper using `timegm` on POSIX/BSD platforms and `_mkgmtime` on Windows.

This PR is based on `develop` and is independent from PR #66.

Validation performed:
- Direct host compile/run against `sysio::time_point::from_iso_string` with `TZ=America/Chicago`, confirming expected UTC epoch values for 1970, 1998, and 2020 timestamps.
- Attempted `cmake --build build-apple-arm64-tests --target time_tests -v`; regeneration failed on current `develop` due unrelated CMake baseline issues in `tools/external/wabt` and Threads detection before the test target could build.

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
