### PR TITLE
Sort ABI desc files before merging

### DIFF
--- a/tools/codegen/cdt-codegen.cpp
+++ b/tools/codegen/cdt-codegen.cpp
@@ -4,6 +4,7 @@
 #include <sysio/whereami/whereami.hpp>
 
 #include <fstream>
+#include <algorithm>
 #include <map>
 #include <set>
 #include <sstream>
@@ -481,6 +482,10 @@ int main(int argc, const char** argv) {
             closedir(dir);
          }
       }
+
+      // Directory iteration order is filesystem-dependent. Keep .desc merge
+      // order stable so ABI output is reproducible across platforms.
+      std::sort(desc_files.begin(), desc_files.end());
 
       ojson abi;
 


### PR DESCRIPTION
## Change Description
Make ABI generation deterministic by sorting collected `.desc` file paths before merging them in `cdt-codegen`.

The previous implementation appended `.desc` files discovered from `readdir` directly into the merge list. Directory iteration order is filesystem-dependent, so multi-translation-unit contracts could merge ABI description files in different orders across Linux and macOS. Sorting the final list before ABI merge keeps the generated ABI stable and is load-bearing for reproducible contract artifacts.

This PR is based on `develop` and isolates the deterministic `.desc` ordering change from PR #66.

Validation performed:
- `git diff --check`

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
