### PR TITLE
Move whereami system includes out of namespace

### DIFF
--- a/tools/include/sysio/whereami/bsd.hpp
+++ b/tools/include/sysio/whereami/bsd.hpp
@@ -1,10 +1,3 @@
-#include <limits.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/sysctl.h>
-#include <dlfcn.h>
-
 template <uint8_t OS>
 int _getExecutablePath(char* out, int capacity, int* dirname_length, typename std::enable_if<OS == sys::_bsd, int>::type = 0) {
   char buffer1[PATH_MAX];
@@ -96,4 +89,3 @@ int _getModulePath(char* out, int capacity, int* dirname_length, typename std::e
 
   return length;
 }
-

--- a/tools/include/sysio/whereami/linux.hpp
+++ b/tools/include/sysio/whereami/linux.hpp
@@ -1,12 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <limits.h>
-#ifndef __STDC_FORMAT_MACROS
-# define __STDC_FORMAT_MACROS
-#endif
-#include <inttypes.h>
-   
 template <uint8_t OS>
 int _getExecutablePath(char* out, int capacity, int* dirname_length, typename std::enable_if<OS == sys::_linux, int>::type = 0) {
   char buffer[PATH_MAX];

--- a/tools/include/sysio/whereami/osx.hpp
+++ b/tools/include/sysio/whereami/osx.hpp
@@ -1,10 +1,3 @@
-#define _DARWIN_BETTER_REALPATH
-#include <mach-o/dyld.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <string.h>
-#include <dlfcn.h>
-
 template <uint8_t OS>
 int _getExecutablePath(char* out, int capacity, int* dirname_length, typename std::enable_if<OS == sys::_osx, int>::type = 0) {
      char buffer1[PATH_MAX];

--- a/tools/include/sysio/whereami/whereami.hpp
+++ b/tools/include/sysio/whereami/whereami.hpp
@@ -1,5 +1,54 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <stdlib.h>
+#include <type_traits>
+#include <vector>
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#if defined(_MSC_VER)
+#pragma warning(push, 3)
+#endif
+#include <windows.h>
+#include <intrin.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+#define __SYSIO_OS__ sys::_win
+
+#elif defined(__linux__) || defined(__CYGWIN__)
+#ifndef __STDC_FORMAT_MACROS
+# define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#define __SYSIO_OS__ sys::_linux
+
+#elif defined(__APPLE__)
+#define _DARWIN_BETTER_REALPATH
+#include <dlfcn.h>
+#include <limits.h>
+#include <mach-o/dyld.h>
+#include <string.h>
+#define __SYSIO_OS__ sys::_osx
+
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || \
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+#include <dlfcn.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#define __SYSIO_OS__ sys::_bsd
+
+#else
+#error unsupported platform
+#endif
+
 namespace sysio { namespace cdt {
 enum sys {
    _win,
@@ -8,26 +57,15 @@ enum sys {
    _bsd
 };
 
-#include <stdlib.h>
 #if defined(_WIN32)
 #include "win.hpp"
-#define __SYSIO_OS__ sys::_win
-
 #elif defined(__linux__) || defined(__CYGWIN__)
 #include "linux.hpp"
-#define __SYSIO_OS__ sys::_linux
-
 #elif defined(__APPLE__)
 #include "osx.hpp"
-#define __SYSIO_OS__ sys::_osx
-
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || \
       defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 #include "bsd.hpp"
-#define __SYSIO_OS__ sys::_bsd
-
-#else
-#error unsupported platform
 #endif
 
 struct whereami {

--- a/tools/include/sysio/whereami/win.hpp
+++ b/tools/include/sysio/whereami/win.hpp
@@ -1,14 +1,3 @@
-#define WIN32_LEAN_AND_MEAN
-#if defined(_MSC_VER)
-#pragma warning(push, 3)
-#endif
-#include <windows.h>
-#include <intrin.h>
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-#endif
-
 template <uint8_t OS>
 int _getModulePath(HMODULE module, char* out, int capacity, int* dirname_length, typename std::enable_if<OS == sys::_win, int>::type = 0) {
    wchar_t buffer1[MAX_PATH];


### PR DESCRIPTION
## Change Description
Move `whereami` system/library includes out of `namespace sysio::cdt` while keeping the platform implementation templates inside the CDT namespace.

The previous layout included platform headers from inside `namespace sysio::cdt`; those platform headers also pulled in C/system headers such as `<dlfcn.h>`, `<mach-o/dyld.h>`, `<inttypes.h>`, and `<windows.h>`. Including system headers inside a project namespace can nest declarations into that namespace and create platform-specific compile issues. This PR centralizes the system includes in `whereami.hpp` before opening the namespace, then includes the platform implementation header after the `sys` enum is declared.

This PR is based on `develop` and isolates the `whereami.hpp` include-order fix from PR #66.

Validation performed:
- `git diff --check`
- Compiled a small macOS TU including `<sysio/whereami/whereami.hpp>` and calling `sysio::cdt::whereami::getExecutablePath`.

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
