### PR TITLE
Use softfloat helper for f32 arithmetic returns

### DIFF
--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -167,19 +167,19 @@ extern "C" {
 
    float _sysio_f32_add( float a, float b ) {
       float32_t ret = f32_add( to_softfloat32(a), to_softfloat32(b) );
-      return *reinterpret_cast<float*>(&ret);
+      return from_softfloat32(ret);
    }
    float _sysio_f32_sub( float a, float b ) {
       float32_t ret = f32_sub( to_softfloat32(a), to_softfloat32(b) );
-      return *reinterpret_cast<float*>(&ret);
+      return from_softfloat32(ret);
    }
    float _sysio_f32_div( float a, float b ) {
       float32_t ret = f32_div( to_softfloat32(a), to_softfloat32(b) );
-      return *reinterpret_cast<float*>(&ret);
+      return from_softfloat32(ret);
    }
    float _sysio_f32_mul( float a, float b ) {
       float32_t ret = f32_mul( to_softfloat32(a), to_softfloat32(b) );
-      return *reinterpret_cast<float*>(&ret);
+      return from_softfloat32(ret);
    }
    float _sysio_f32_min( float af, float bf ) {
       float32_t a = to_softfloat32(af);


### PR DESCRIPTION
## Change Description
Replace strict-aliasing-unsafe `reinterpret_cast<float*>` returns in the native softfloat f32 arithmetic helpers with the existing `from_softfloat32` conversion helper.

`float32_t` stores the softfloat result bits in a struct, so reading the result through `reinterpret_cast<float*>(&ret)` violates strict aliasing. Other f32 helpers in the same file already use `from_softfloat32`, including `_sysio_f32_sqrt`, so this makes `_sysio_f32_add`, `_sysio_f32_sub`, `_sysio_f32_div`, and `_sysio_f32_mul` consistent with the safe pattern.

This PR is based on `develop` and isolates the native f32 aliasing fix from PR #66.

Validation performed:
- `git diff --check`
- Confirmed no `reinterpret_cast<float*>` usage remains in `libraries/native/intrinsics.cpp`.
- Attempted `cmake --build build-apple-arm64-tests --target native -v`; regeneration failed on current `develop` due unrelated CMake baseline issues in `tools/external/wabt` and Threads/absl detection before `native` could compile.

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
