### PR TITLE
Fix native 128-bit hex printers

### DIFF
--- a/libraries/native/crt.cpp
+++ b/libraries/native/crt.cpp
@@ -2,13 +2,23 @@
 #include <sysio/action.hpp>
 #include "native/sysio/intrinsics.hpp"
 #include "native/sysio/crt.hpp"
+#include <array>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <stdio.h>
 #include <setjmp.h>
 
 sysio::cdt::output_stream std_out;
 sysio::cdt::output_stream std_err;
+
+namespace {
+   void print_hex_128(const void* value) {
+      std::array<uint32_t, 4> words{};
+      std::memcpy(words.data(), value, sizeof(words));
+      printf("0x%08x%08x%08x%08x", words[0], words[1], words[2], words[3]);
+   }
+}
 
 extern "C" {
    int main(int, char**);
@@ -96,12 +106,10 @@ extern "C" {
             printf("%llu", v);
          });
       intrinsics::set_intrinsic<intrinsics::printi128>([](const int128_t* v) {
-            int* tmp = (int*)v;
-            printf("0x%04x%04x%04x%04x", tmp[0], tmp[1], tmp[2], tmp[3]);
+            print_hex_128(v);
          });
       intrinsics::set_intrinsic<intrinsics::printui128>([](const uint128_t* v) {
-            int* tmp = (int*)v;
-            printf("0x%04x%04x%04x%04x", tmp[0], tmp[1], tmp[2], tmp[3]);
+            print_hex_128(v);
          });
       intrinsics::set_intrinsic<intrinsics::printsf>([](float v) {
             char buff[512] = {0};
@@ -132,8 +140,7 @@ extern "C" {
             prints(buff);
          });
       intrinsics::set_intrinsic<intrinsics::printqf>([](const long double* v) {
-            int* tmp = (int*)v;
-            printf("0x%04x%04x%04x%04x", tmp[0], tmp[1], tmp[2], tmp[3]);
+            print_hex_128(v);
          });
       intrinsics::set_intrinsic<intrinsics::printn>([](uint64_t nm) {
             std::string s = sysio::name(nm).to_string();

--- a/tests/unit/print_tests.cpp
+++ b/tests/unit/print_tests.cpp
@@ -18,7 +18,7 @@ SYSIO_TEST_BEGIN(print_test)
    CHECK_PRINT("-404", [](){ sysio::print((int32_t)-404); });
    CHECK_PRINT("404000000", [](){ sysio::print((uint64_t)404000000); });
    CHECK_PRINT("-404000000", [](){ sysio::print((int64_t)-404000000); });
-   CHECK_PRINT("0x0066000000000000", [](){ sysio::print((uint128_t)102); });
+   CHECK_PRINT("0x00000066000000000000000000000000", [](){ sysio::print((uint128_t)102); });
    CHECK_PRINT("0xffffff9affffffffffffffffffffffff", [](){ sysio::print((int128_t)-102); });
 SYSIO_TEST_END
 


### PR DESCRIPTION
## Change Description
Fix the native 128-bit hex printers in `libraries/native/crt.cpp`.

The previous implementation read `int128_t`, `uint128_t`, and `long double` values through `int*`, which violates strict aliasing and drops constness. It also formatted each 32-bit word with `%04x`, which only guarantees four hex digits even though each word is 32 bits. This change copies the 128-bit value bytes into four `uint32_t` words with `std::memcpy` and prints each word with `%08x`, preserving the existing word order while avoiding the aliasing violation.

This PR is based on `develop` and isolates the native CRT printer fix from PR #66.

Validation performed:
- `git diff --check`
- Confirmed the old `(int*)` casts and `%04x` 128-bit printer formatting are removed from `libraries/native/crt.cpp`.
- Attempted `cmake --build build-apple-arm64-tests --target native -v`; regeneration failed on current `develop` due unrelated CMake baseline issues in `tools/external/wabt` and Threads/absl detection before `native` could compile.

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
