### PR TITLE
Fix output stream overflow test string

### DIFF
--- a/tests/unit/crt_tests.cpp
+++ b/tests/unit/crt_tests.cpp
@@ -33,10 +33,10 @@ SYSIO_TEST_BEGIN(output_stream_push_overflow)
    const auto initial_capacity = std_err.to_string().capacity();
    CHECK_EQUAL(std_err.index(), 0);
 
-   std::string large_msg('x', initial_capacity + 1);
+   std::string large_msg(initial_capacity + 1, 'x');
 
    _prints(large_msg.c_str(), sysio::cdt::output_stream_kind::std_err);
-   CHECK_EQUAL(std_err.to_string().capacity() > initial_capacity, true);
+   CHECK_EQUAL(std_err.to_string().capacity() >= large_msg.size(), true);
    CHECK_EQUAL(std_err.index(), large_msg.size());
 
    std_err.clear();


### PR DESCRIPTION
## Change Description
Fix the `output_stream_push_overflow` unit test so it actually constructs a string with `initial_capacity + 1` copies of `'x'`.

The previous constructor call used the arguments in the wrong order: `std::string large_msg('x', initial_capacity + 1)`. That made `'x'` the count and narrowed `initial_capacity + 1` into the fill character, so the test happened to exercise overflow by accident rather than by intent. This change uses `std::string large_msg(initial_capacity + 1, 'x')` and keeps the portable capacity assertion based on the actual message size.

This PR is based on `develop` and isolates the `crt_tests.cpp` test fix from PR #66.

Validation performed:
- `git diff --check`
- Attempted `cmake --build build-apple-arm64-tests --target crt_tests -v`; regeneration failed locally on current `develop` due unrelated CMake baseline issues in `tools/external/wabt` and Threads/absl detection before `crt_tests` could build.

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
