### PR TITLE
Fix Mach-O x86 mmap size

### DIFF
--- a/libraries/native/macho_crt.s
+++ b/libraries/native/macho_crt.s
@@ -30,7 +30,7 @@ ____putc:
 __mmap:
    mov $0x20000C5, %eax # mmap syscall 0xC5 or 197
    mov $0, %rdi          # don't map
-   mov $0x640000000, %rsi  # size 100Mb 
+   mov $0x6400000, %rsi    # size 100Mb
    mov $3, %rdx         
    mov $0x1002, %r10
    mov $-1, %r8


### PR DESCRIPTION
## Change Description
Fix the x86_64 Mach-O CRT mmap size constant to allocate 100 MiB instead of ~25 GiB.

`libraries/native/macho_crt.s` documented the mapping size as 100 MB, but used `0x640000000` for the mmap length. The intended 100 MiB literal is `0x6400000`, matching the existing ELF CRT value and the arm64 Mach-O implementation in the macOS support work.

This PR is based on `develop` and isolates the x86 Mach-O CRT constant fix from PR #66.

Validation performed:
- `git diff --check`
- Confirmed `elf_crt.s` and `macho_crt.s` now use the same `0x6400000` mmap size literal.

## API Changes

- [ ] API Changes

## Documentation Additions

- [ ] Documentation Additions
