### PR TITLE
Order secp256k1 public keys with unsigned bytes to match the chain's authority ordering

### DIFF
--- a/libraries/sysiolib/core/sysio/crypto.hpp
+++ b/libraries/sysiolib/core/sysio/crypto.hpp
@@ -23,11 +23,23 @@ namespace sysio {
    /**
     *  SYSIO ECC public key data
     *
-    *  Fixed size representation of either a K1 or R1 compressed public key
-
+    *  Fixed size representation of a K1, R1, or EM (Ethereum secp256k1)
+    *  compressed public key.
+    *
+    *  The element type is unsigned (`uint8_t`) on purpose: the chain orders
+    *  authority keys with an unsigned byte comparison (`fc::crypto`'s
+    *  `less_comparator` uses `std::memcmp`). `std::array`'s `operator<` is a
+    *  lexicographical compare over its element type, so a signed `char` element
+    *  would order any key byte >= 0x80 as negative and disagree with the chain
+    *  for ~25% of key pairs -- a contract that sorts such keys into an authority
+    *  would then have `updateauth` reject it as unsorted. `uint8_t` keeps the
+    *  contract-side ordering identical to the chain's (and consistent with
+    *  `ed_public_key`/`bls_public_key`, which already use unsigned bytes).
+    *  The on-wire serialization is unchanged -- 33 raw bytes either way.
+    *
     *  @ingroup public_key
     */
-   using ecc_public_key = std::array<char, 33>;
+   using ecc_public_key = std::array<uint8_t, 33>;
 
    /**
     *  SYSIO WebAuthN public key

--- a/tests/unit/crypto_tests.cpp
+++ b/tests/unit/crypto_tests.cpp
@@ -17,13 +17,43 @@ using namespace sysio::native;
 SYSIO_TEST_BEGIN(public_key_type_test)
    // -----------------------------------------------------
    // bool operator==(const public_key&, const public_key&)
-   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{})  == public_key(std::in_place_index<0>, std::array<char, 33>{})), true  )
-   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{1}) == public_key(std::in_place_index<0>, std::array<char, 33>{})), false )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<uint8_t, 33>{})  == public_key(std::in_place_index<0>, std::array<uint8_t, 33>{})), true  )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<uint8_t, 33>{1}) == public_key(std::in_place_index<0>, std::array<uint8_t, 33>{})), false )
 
    // -----------------------------------------------------
    // bool operator!=(const public_key&, const public_key&)
-   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{})  != public_key(std::in_place_index<0>, std::array<char, 33>{})), false )
-   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{1}) != public_key(std::in_place_index<0>, std::array<char, 33>{})), true  )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<uint8_t, 33>{})  != public_key(std::in_place_index<0>, std::array<uint8_t, 33>{})), false )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<uint8_t, 33>{1}) != public_key(std::in_place_index<0>, std::array<uint8_t, 33>{})), true  )
+SYSIO_TEST_END
+
+// operator< on public_key must match the chain's canonical key ordering, which
+// is an UNSIGNED byte comparison (libfc's authority validate() -> less_comparator
+// -> std::memcmp). ecc_public_key is std::array<uint8_t,33>, so std::array's
+// lexicographical operator< compares unsigned and agrees with the chain. A signed
+// `char` element would order any key byte >= 0x80 as negative and disagree, so a
+// contract that sorts such keys into an authority would have updateauth reject it
+// as unsorted. These cases pin the unsigned behavior (the regression guard the old
+// equality-only test lacked).
+SYSIO_TEST_BEGIN(public_key_ordering_test)
+   auto ecc = []( uint8_t second_byte ) {
+      std::array<uint8_t, 33> a{};
+      a[0] = 0x02;              // compressed-point prefix (irrelevant to the test)
+      a[1] = second_byte;       // first byte that actually differs below
+      return public_key( std::in_place_index<0>, a );
+   };
+   const public_key hi = ecc( 0x80 );   // high bit set -> 128 unsigned, -128 signed
+   const public_key lo = ecc( 0x01 );   //                   1 unsigned,    1 signed
+
+   // Unsigned: 0x80 (128) > 0x01 (1). Signed char would invert both of these.
+   CHECK_EQUAL( (lo < hi), true  )
+   CHECK_EQUAL( (hi < lo), false )
+
+   // Different variant index always orders by index first, regardless of bytes:
+   // a K1 key (index 0) precedes an EM key (index 3) even though `hi`'s bytes are
+   // larger than the empty EM key's.
+   const public_key em_zero( std::in_place_index<3>, std::array<uint8_t, 33>{} );
+   CHECK_EQUAL( (hi < em_zero), true  )
+   CHECK_EQUAL( (em_zero < hi), false )
 SYSIO_TEST_END
 
 // Definitions in `sysio.cdt/libraries/sysio/crypto.hpp`
@@ -49,8 +79,8 @@ SYSIO_TEST_END
 SYSIO_TEST_BEGIN(try_recover_key_test)
    // Deterministic K1 public key (variant index 0) round-tripped through the
    // stub so the recovered key is checkable without a real secp256k1 vector.
-   std::array<char, 33> raw{};
-   for ( size_t i = 0; i < raw.size(); ++i ) raw[i] = static_cast<char>(i + 1);
+   std::array<uint8_t, 33> raw{};
+   for ( size_t i = 0; i < raw.size(); ++i ) raw[i] = static_cast<uint8_t>(i + 1);
    const public_key expected( std::in_place_index<0>, raw );
    const std::vector<char> packed = sysio::pack( expected );
 
@@ -95,6 +125,7 @@ int main(int argc, char* argv[]) {
    silence_output(!verbose);
 
    SYSIO_TEST(public_key_type_test)
+   SYSIO_TEST(public_key_ordering_test)
    SYSIO_TEST(signature_type_test)
    SYSIO_TEST(try_recover_key_test)
    return has_failed();


### PR DESCRIPTION
## Problem
sysio::ecc_public_key (the k1/r1/em alternatives of sysio::public_key) was std::array<char,33>, so std::variant/std::array operator< compares the key bytes as signed char. The chain orders authority keys with an UNSIGNED comparison — libfc's authority::validate() routes public_key::operator< through less_comparator -> std::memcmp. The two disagree whenever two same-type keys first differ at a byte >= 0x80.

Any contract that sorts secp256k1 public keys into an authority and submits it via updateauth then hits this: the contract's order is rejected as unsorted ("Invalid authority"). sysio.system::expandauth (used by sysio.authex::createlink) is the first contract to do so, which is how it surfaced (wire-sysio #362 https://github.com/Wire-Network/wire-sysio/pull/362).

## Root cause
Latent defect inherited from upstream https://github.com/antelopeIO/cdt — the signed char[] ecc key predates the eosio->sysio rename, and nothing exercised it because no stock contract sorted secp256k1 keys into a chain-validated authority. ed_public_key/bls_public_key already use uint8_t (correct); the secp256k1 family was the outlier.

## Fix
ecc_public_key -> std::array<uint8_t,33>. Wire/ABI-identical (33 raw bytes either way); only operator< changes, now matching the chain's memcmp ordering. public_key_ordering_test pins it with a high-bit (>= 0x80) byte and cross-type index ordering; the prior equality-only public_key_type_test could not catch it.
