### PR TITLE
Wrap protobuf int32 storage

### DIFF
--- a/docs/protocol-buffers.md
+++ b/docs/protocol-buffers.md
@@ -136,8 +136,8 @@ clio push action mycontract settle \
 - The ABI generator detects `sysio::pb<T>` and encodes the type as `protobuf::mypackage.TransferData`
 - **Single `pb<T>` parameter**: action type points directly at the protobuf type (flat JSON)
 - **Multiple parameters**: a wrapper struct is generated (nested JSON)
-- Protobuf integer types use `zpp::bits` varint wrappers (`vint64_t`, `vuint64_t`, etc.)
-- Varint types don't implicitly convert — use `static_cast<int32_t>(field)` to access the underlying value
+- Protobuf integer types use protobuf-aware wrappers (`sysio::pb_int32`, `zpp::bits::vint64_t`, `vuint64_t`, etc.)
+- `sysio::pb_int32` implicitly converts to `int32_t`; zpp varint types don't implicitly convert, so use an explicit cast to access their underlying values
 
 ## Generated ABI
 
@@ -224,7 +224,7 @@ The `pb_members<N>` declaration (where N is the number of fields) enables protob
 
 | Proto3 Type | C++ Type |
 |------------|----------|
-| `int32` | `zpp::bits::vint64_t` |
+| `int32` | `sysio::pb_int32` |
 | `int64` | `zpp::bits::vint64_t` |
 | `uint32` | `zpp::bits::vuint32_t` |
 | `uint64` | `zpp::bits::vuint64_t` |
@@ -239,7 +239,7 @@ The `pb_members<N>` declaration (where N is the number of fields) enables protob
 | `bool` | `bool` |
 | `string` | `std::string` |
 | `bytes` | `std::vector<char>` |
-| `enum` | C++ `enum : int64_t` |
+| `enum` | C++ `enum : int32_t` |
 | `message` | C++ `struct` |
 | `repeated T` | `std::vector<T>` |
 | `map<K,V>` | `std::map<K,V>` |
@@ -249,5 +249,6 @@ The `pb_members<N>` declaration (where N is the number of fields) enables protob
 - Only proto3 syntax is supported
 - `oneof` fields are not supported
 - `std::optional` fields (`[(zpp.zpp_optional) = true]`) are not supported — stock `zpp_bits` does not support optional fields in protobuf serialization mode
+- Negative enum values are not supported
 - Unpacked repeated fields are not supported
 - WASM contracts have no exception support; serialization errors abort via `sysio::check()`

--- a/libraries/sysiolib/core/sysio/pb.hpp
+++ b/libraries/sysiolib/core/sysio/pb.hpp
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <algorithm>
+#include <compare>
+#include <concepts>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <tuple>
 #include <utility>
 #include <type_traits>
 #include <span>
@@ -7,6 +14,351 @@
 #include <sysio/datastream.hpp>
 
 namespace sysio {
+
+   /// Protobuf int32 field storage with protobuf-compatible varint encoding.
+   /// Negative int32 values are stored in 32 bits but encoded through a signed
+   /// 64-bit varint, which matches protobuf's sign-extended int32 wire format.
+   struct pb_int32 {
+      int32_t value = 0;
+
+      constexpr pb_int32() = default;
+      constexpr pb_int32(int32_t v) : value(v) {}
+
+      constexpr operator int32_t&() & { return value; }
+      constexpr operator int32_t() const { return value; }
+
+      constexpr pb_int32& operator=(int32_t v) {
+         value = v;
+         return *this;
+      }
+
+      friend bool operator==(const pb_int32&, const pb_int32&) = default;
+      friend auto operator<=>(const pb_int32&, const pb_int32&) = default;
+   };
+
+   template <typename Archive>
+   constexpr auto serialize(Archive& archive, pb_int32 self) requires(Archive::kind() == zpp::bits::kind::out) {
+      return archive(zpp::bits::vint64_t{static_cast<int64_t>(self.value)});
+   }
+
+   template <typename Archive>
+   constexpr auto serialize(Archive& archive, pb_int32& self) requires(Archive::kind() == zpp::bits::kind::in) {
+      zpp::bits::vint64_t wire_value;
+      if (auto result = archive(wire_value); result != std::errc{}) {
+         return result;
+      }
+      self.value = static_cast<int32_t>(static_cast<int64_t>(wire_value));
+      return zpp::bits::errc{};
+   }
+
+   template <typename T>
+   inline constexpr bool is_pb_int32_v = std::same_as<std::remove_cvref_t<T>, pb_int32>;
+
+   template <typename>
+   inline constexpr bool dependent_false_v = false;
+
+   /// zpp_bits' protobuf protocol does not accept class field types unless they
+   /// are messages, so `pb_protocol` mirrors the upstream protocol at the field
+   /// dispatch boundary and injects protobuf int32 handling for `sysio::pb_int32`.
+   /// Non-int32 field categories delegate to `zpp::bits::pb` where that protocol
+   /// can represent them directly.
+   template <typename... Options>
+   struct pb_protocol : zpp::bits::pb<Options...> {
+      using base = zpp::bits::pb<Options...>;
+      using pb_default = pb_protocol<>;
+
+      constexpr pb_protocol(Options&&... options) : base(std::forward<Options>(options)...) {}
+
+      template <typename Type>
+      constexpr static auto check_type() {
+         using type = std::remove_cvref_t<Type>;
+         if constexpr (is_pb_int32_v<type>) {
+            return true;
+         } else if constexpr (base::template is_pb_field<type>()) {
+            return check_type<typename type::pb_field_type>();
+         } else if constexpr (!std::is_class_v<type> || zpp::bits::concepts::varint<type> ||
+                              zpp::bits::concepts::empty<type>) {
+            return true;
+         } else if constexpr (zpp::bits::concepts::associative_container<type> &&
+                              requires { typename type::mapped_type; }) {
+            static_assert(requires { type{}.push_back(typename type::value_type{}); } ||
+                          requires { type{}.insert(typename type::value_type{}); });
+            static_assert(check_type<typename type::key_type>());
+            static_assert(check_type<typename type::mapped_type>());
+            return true;
+         } else if constexpr (zpp::bits::concepts::container<type>) {
+            static_assert(requires { type{}.push_back(typename type::value_type{}); } ||
+                          requires { type{}.insert(typename type::value_type{}); });
+            static_assert(check_type<typename type::value_type>());
+            return true;
+         } else if constexpr (zpp::bits::concepts::by_protocol<type>) {
+            return true;
+         } else {
+            static_assert(dependent_false_v<Type>, "pb_protocol: unsupported protobuf field type");
+         }
+      }
+
+      ZPP_BITS_INLINE constexpr auto operator()(auto& archive, auto& item) const
+         requires(std::remove_cvref_t<decltype(archive)>::kind() == zpp::bits::kind::out)
+      {
+         using type = std::remove_cvref_t<decltype(item)>;
+         static_assert(check_type<type>());
+
+         return zpp::bits::visit_members(item, [&](auto&&... items) {
+            static_assert((... && check_type<decltype(items)>()));
+            return serialize_many(std::make_index_sequence<sizeof...(items)>{}, archive, items...);
+         });
+      }
+
+      ZPP_BITS_INLINE constexpr auto operator()(auto& archive,
+                                                auto& item,
+                                                std::size_t size = std::numeric_limits<std::size_t>::max()) const
+         requires(std::remove_cvref_t<decltype(archive)>::kind() == zpp::bits::kind::in)
+      {
+         auto data = archive.remaining_data();
+         zpp::bits::in in{std::span{data.data(), std::min(size, data.size())},
+                          zpp::bits::size_varint{},
+                          zpp::bits::endian::little{},
+                          zpp::bits::alloc_limit<std::remove_cvref_t<decltype(archive)>::allocation_limit>{}};
+         auto result = deserialize_fields(in, item);
+         archive.position() += in.position();
+         return result;
+      }
+
+      template <std::size_t FirstIndex, std::size_t... Indices>
+      ZPP_BITS_INLINE constexpr static zpp::bits::errc serialize_many(std::index_sequence<FirstIndex, Indices...>,
+                                                                      auto& archive,
+                                                                      auto& first_item,
+                                                                      auto&... items) {
+         if (auto result = serialize_one<FirstIndex>(archive, first_item); zpp::bits::failure(result)) {
+            return result;
+         }
+
+         return serialize_many(std::index_sequence<Indices...>{}, archive, items...);
+      }
+
+      ZPP_BITS_INLINE constexpr static zpp::bits::errc serialize_many(std::index_sequence<>, auto&) {
+         return {};
+      }
+
+      template <std::size_t Index, typename TagType = void>
+      ZPP_BITS_INLINE constexpr static zpp::bits::errc serialize_one(auto& archive, auto& item) {
+         using type = std::remove_cvref_t<decltype(item)>;
+         using tag_type = std::conditional_t<std::is_void_v<TagType>, type, TagType>;
+
+         if constexpr (zpp::bits::concepts::empty<type>) {
+            return {};
+         } else if constexpr (is_pb_int32_v<type>) {
+            constexpr auto tag = base::template make_tag<zpp::bits::vint64_t, Index>();
+            return archive(tag, zpp::bits::vint64_t{static_cast<int64_t>(item)});
+         } else if constexpr (base::template is_pb_field<type>()) {
+            return serialize_one<Index, tag_type>(archive, static_cast<const typename type::pb_field_type&>(item));
+         } else if constexpr (std::is_enum_v<type> && !std::same_as<type, std::byte>) {
+            constexpr auto tag = base::template make_tag<tag_type, Index>();
+            return archive(tag, zpp::bits::varint{std::underlying_type_t<type>(item)});
+         } else if constexpr (!zpp::bits::concepts::container<type>) {
+            constexpr auto tag = base::template make_tag<tag_type, Index>();
+            return archive(tag, item);
+         } else if constexpr (zpp::bits::concepts::associative_container<type> &&
+                              requires { typename type::mapped_type; }) {
+            constexpr auto tag = base::template make_tag<tag_type, Index>();
+
+            using key_type = std::conditional_t<
+               std::is_enum_v<typename type::key_type> && !std::same_as<typename type::key_type, std::byte>,
+               zpp::bits::varint<typename type::key_type>,
+               typename type::key_type>;
+
+            using mapped_type = std::conditional_t<
+               std::is_enum_v<typename type::mapped_type> && !std::same_as<typename type::mapped_type, std::byte>,
+               zpp::bits::varint<typename type::mapped_type>,
+               typename type::mapped_type>;
+
+            struct value_type {
+               const key_type& key;
+               const mapped_type& value;
+
+               using serialize = zpp::bits::protocol<pb_protocol{}>;
+               serialize use();
+            };
+
+            for (auto& [key, value] : item) {
+               if (auto result = archive(tag, value_type{.key = key, .value = value}); zpp::bits::failure(result)) {
+                  return result;
+               }
+            }
+
+            return {};
+         } else if constexpr (requires { requires is_pb_int32_v<typename type::value_type>; }) {
+            constexpr auto tag =
+               base::template make_tag<base::wire_type::length_delimited, zpp::bits::vint64_t, Index>();
+            std::size_t size = {};
+            for (auto& element : item) {
+               size += zpp::bits::varint_size(static_cast<int64_t>(element));
+            }
+            if (!size) {
+               return {};
+            }
+            // Keep this in lockstep with serialize(Archive&, pb_int32): the
+            // packed length is precomputed from the same vint64_t bytes that
+            // unsized(item) writes for each pb_int32 element.
+            return archive(tag, zpp::bits::varint{size}, zpp::bits::unsized(item));
+         } else {
+            return base::template serialize_one<Index, TagType>(archive, item);
+         }
+      }
+
+      ZPP_BITS_INLINE constexpr static zpp::bits::errc deserialize_fields(auto& archive, auto& item) {
+         using type = std::remove_cvref_t<decltype(item)>;
+         static_assert(check_type<type>());
+
+         auto size = archive.data().size();
+         zpp::bits::visit_members(item, [](auto&&... members) {
+            (([](auto&& member) {
+                using member_type = std::remove_cvref_t<decltype(member)>;
+                if constexpr (zpp::bits::concepts::container<member_type> &&
+                              !std::is_fundamental_v<member_type> &&
+                              !std::same_as<member_type, std::byte> &&
+                              requires { member.clear(); }) {
+                   member.clear();
+                }
+             }(members)),
+             ...);
+         });
+
+         while (archive.position() < size) {
+            zpp::bits::vuint32_t tag;
+            if (auto result = archive(tag); zpp::bits::failure(result)) {
+               return result;
+            }
+
+            if (auto result = deserialize_field(archive, item, base::tag_number(tag), base::tag_type(tag));
+                zpp::bits::failure(result)) {
+               return result;
+            }
+         }
+
+         return {};
+      }
+
+      template <std::size_t Index = 0>
+      ZPP_BITS_INLINE constexpr static auto deserialize_field(auto& archive,
+                                                             auto&& item,
+                                                             auto field_num,
+                                                             typename base::wire_type field_type) {
+         using type = std::remove_reference_t<decltype(item)>;
+         if constexpr (Index >= zpp::bits::number_of_members<type>()) {
+            if (!field_num) {
+               return zpp::bits::errc{std::errc::protocol_error};
+            }
+            return zpp::bits::errc{};
+         } else if (base::template field_number_from_struct<type, Index>() != field_num) {
+            return deserialize_field<Index + 1>(archive, item, field_num, field_type);
+         } else {
+            return zpp::bits::visit_members(item, [&](auto&&... items) {
+               std::tuple<decltype(items)&...> refs = {items...};
+               auto& field = std::get<Index>(refs);
+               using field_type_t = std::remove_reference_t<decltype(field)>;
+               static_assert(check_type<field_type_t>());
+
+               return deserialize_field(archive, field_type, field);
+            });
+         }
+      }
+
+      ZPP_BITS_INLINE constexpr static auto deserialize_field(auto& archive,
+                                                             typename base::wire_type field_type,
+                                                             auto& item) {
+         using type = std::remove_reference_t<decltype(item)>;
+         static_assert(check_type<type>());
+
+         if constexpr (is_pb_int32_v<type>) {
+            zpp::bits::vint64_t value;
+            if (auto result = archive(value); zpp::bits::failure(result)) {
+               return result;
+            }
+            item = static_cast<int32_t>(static_cast<int64_t>(value));
+            return zpp::bits::errc{};
+         } else if constexpr (std::is_enum_v<type>) {
+            zpp::bits::varint<type> value;
+            if (auto result = archive(value); zpp::bits::failure(result)) {
+               return result;
+            }
+            item = value;
+            return zpp::bits::errc{};
+         } else if constexpr (base::template is_pb_field<type>()) {
+            return deserialize_field(archive, field_type, static_cast<typename type::pb_field_type&>(item));
+         } else if constexpr (!zpp::bits::concepts::container<type>) {
+            return archive(item);
+         } else if constexpr (zpp::bits::concepts::associative_container<type> &&
+                              requires { typename type::mapped_type; }) {
+            using key_type = std::conditional_t<
+               std::is_enum_v<typename type::key_type> && !std::same_as<typename type::key_type, std::byte>,
+               zpp::bits::varint<typename type::key_type>,
+               typename type::key_type>;
+
+            using mapped_type = std::conditional_t<
+               std::is_enum_v<typename type::mapped_type> && !std::same_as<typename type::mapped_type, std::byte>,
+               zpp::bits::varint<typename type::mapped_type>,
+               typename type::mapped_type>;
+
+            struct value_type {
+               key_type key;
+               mapped_type value;
+
+               using serialize = zpp::bits::protocol<pb_protocol{}>;
+               serialize use();
+            };
+
+            alignas(value_type) std::byte storage[sizeof(value_type)];
+
+            auto object = zpp::bits::access::placement_new<value_type>(std::addressof(storage));
+            zpp::bits::destructor_guard guard{*object};
+            if (auto result = archive(*object); zpp::bits::failure(result)) {
+               return result;
+            }
+
+            item.emplace(std::move(object->key), std::move(object->value));
+            return zpp::bits::errc{};
+         } else if constexpr (requires { requires is_pb_int32_v<typename type::value_type>; }) {
+            auto fetch = [&]() {
+               pb_int32 value;
+               if (auto result = archive(value); zpp::bits::failure(result)) {
+                  return result;
+               }
+
+               if constexpr (requires { item.push_back(value); }) {
+                  item.push_back(value);
+               } else {
+                  item.insert(value);
+               }
+
+               return zpp::bits::errc{};
+            };
+
+            if (field_type != base::wire_type::length_delimited) {
+               return fetch();
+            }
+
+            zpp::bits::vsize_t length;
+            if (auto result = archive(length); zpp::bits::failure(result)) {
+               return result;
+            }
+
+            auto end_position = length + archive.position();
+            while (archive.position() < end_position) {
+               if (auto result = fetch(); zpp::bits::failure(result)) {
+                  return result;
+               }
+            }
+            return zpp::bits::errc{};
+         } else {
+            return base::deserialize_field(archive, field_type, item);
+         }
+      }
+   };
+
+   template <std::size_t Members>
+   using pb_members = zpp::bits::protocol<pb_protocol{}, Members>;
 
    /// Wrapper for protobuf message types used as action parameters.
    /// When the ABI generator sees `sysio::pb<T>`, it encodes the type as
@@ -91,6 +443,16 @@ namespace sysio {
    }
 
    // --- zpp::bits varint JSON/binary serialization helpers ---
+
+   inline void from_json(pb_int32& obj, auto& stream) {
+      int32_t val;
+      from_json(val, stream);
+      obj = val;
+   }
+
+   inline void to_json(pb_int32 obj, auto& stream) {
+      to_json(static_cast<int32_t>(obj), stream);
+   }
 
    template<typename T, zpp::bits::varint_encoding Encoding>
    void from_json(zpp::bits::varint<T, Encoding>& obj, auto& stream) {

--- a/libraries/sysiolib/core/sysio/pb.hpp
+++ b/libraries/sysiolib/core/sysio/pb.hpp
@@ -54,6 +54,15 @@ namespace sysio {
    template <typename T>
    inline constexpr bool is_pb_int32_v = std::same_as<std::remove_cvref_t<T>, pb_int32>;
 
+   /// True when a protobuf field is a repeated nested message that must be
+   /// serialized through this protocol rather than the upstream zpp_bits one.
+   template <typename T>
+   inline constexpr bool is_repeated_pb_message_v =
+      zpp::bits::concepts::container<std::remove_cvref_t<T>> &&
+      !zpp::bits::concepts::associative_container<std::remove_cvref_t<T>> &&
+      requires { typename std::remove_cvref_t<T>::value_type; } &&
+      zpp::bits::concepts::by_protocol<typename std::remove_cvref_t<T>::value_type>;
+
    template <typename>
    inline constexpr bool dependent_false_v = false;
 
@@ -202,6 +211,14 @@ namespace sysio {
             // packed length is precomputed from the same vint64_t bytes that
             // unsized(item) writes for each pb_int32 element.
             return archive(tag, zpp::bits::varint{size}, zpp::bits::unsized(item));
+         } else if constexpr (is_repeated_pb_message_v<type>) {
+            constexpr auto tag = base::template make_tag<tag_type, Index>();
+            for (auto& element : item) {
+               if (auto result = archive(tag, element); zpp::bits::failure(result)) {
+                  return result;
+               }
+            }
+            return {};
          } else {
             return base::template serialize_one<Index, TagType>(archive, item);
          }
@@ -349,6 +366,22 @@ namespace sysio {
                if (auto result = fetch(); zpp::bits::failure(result)) {
                   return result;
                }
+            }
+            return zpp::bits::errc{};
+         } else if constexpr (is_repeated_pb_message_v<type>) {
+            if (field_type != base::wire_type::length_delimited) {
+               return zpp::bits::errc{std::errc::protocol_error};
+            }
+
+            typename type::value_type value;
+            if (auto result = archive(value); zpp::bits::failure(result)) {
+               return result;
+            }
+
+            if constexpr (requires { item.push_back(std::move(value)); }) {
+               item.push_back(std::move(value));
+            } else {
+               item.insert(std::move(value));
             }
             return zpp::bits::errc{};
          } else {

--- a/tests/unit/protobuf_wire_tests.cpp
+++ b/tests/unit/protobuf_wire_tests.cpp
@@ -47,6 +47,20 @@ struct protobuf_repeated_int32_values {
    serialize use();
 };
 
+struct protobuf_nested_int32_value {
+   sysio::pb_int32 value = {};
+
+   using serialize = sysio::pb_members<1>;
+   serialize use();
+};
+
+struct protobuf_repeated_nested_values {
+   std::vector<protobuf_nested_int32_value> values = {};
+
+   using serialize = sysio::pb_members<1>;
+   serialize use();
+};
+
 static std::vector<char> encode(const auto& value) {
    std::vector<char> actual;
    zpp::bits::out out(actual, zpp::bits::size_varint{});
@@ -144,6 +158,29 @@ SYSIO_TEST_BEGIN(protobuf_repeated_int32_wire_test)
    }
 SYSIO_TEST_END
 
+SYSIO_TEST_BEGIN(protobuf_repeated_nested_message_wire_test)
+   protobuf_repeated_nested_values value;
+   value.values = {{7}, {-1}};
+
+   const auto actual = encode(value);
+
+   const std::array<unsigned char, 18> expected = {
+      0x11,
+      0x0a, 0x02, 0x08, 0x07,
+      0x0a, 0x0b, 0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+   };
+
+   check_bytes(actual, expected);
+
+   protobuf_repeated_nested_values decoded;
+   CHECK_EQUAL(decode(actual, decoded), std::errc{})
+   CHECK_EQUAL(decoded.values.size(), static_cast<std::size_t>(2))
+   if (decoded.values.size() == 2) {
+      CHECK_EQUAL(static_cast<int32_t>(decoded.values[0].value), 7)
+      CHECK_EQUAL(static_cast<int32_t>(decoded.values[1].value), -1)
+   }
+SYSIO_TEST_END
+
 SYSIO_TEST_BEGIN(protobuf_int64_negative_wire_test)
    check_int64_value(
       -2,
@@ -181,6 +218,7 @@ int main(int argc, char** argv) {
 
    SYSIO_TEST(protobuf_int32_boundary_wire_test);
    SYSIO_TEST(protobuf_repeated_int32_wire_test);
+   SYSIO_TEST(protobuf_repeated_nested_message_wire_test);
    SYSIO_TEST(protobuf_int64_negative_wire_test);
    SYSIO_TEST(protobuf_int32_and_enum_wire_test);
    return has_failed();

--- a/tests/unit/protobuf_wire_tests.cpp
+++ b/tests/unit/protobuf_wire_tests.cpp
@@ -10,33 +10,40 @@
 #include <span>
 #include <vector>
 
+#include <sysio/pb.hpp>
 #include <sysio/tester.hpp>
-#include <zpp_bits.h>
 
-enum negative_enum : int64_t {
+enum positive_enum : int32_t {
    zero = 0,
-   negative = -1,
+   positive = 42,
 };
 
 struct protobuf_int32_value {
-   zpp::bits::vint64_t value = {};
+   sysio::pb_int32 value = {};
 
-   using serialize = zpp::bits::pb_members<1>;
+   using serialize = sysio::pb_members<1>;
    serialize use();
 };
 
 struct protobuf_int64_value {
    zpp::bits::vint64_t value = {};
 
-   using serialize = zpp::bits::pb_members<1>;
+   using serialize = sysio::pb_members<1>;
    serialize use();
 };
 
 struct protobuf_negative_values {
-   zpp::bits::vint64_t int32_value = {};
-   negative_enum enum_value = zero;
+   sysio::pb_int32 int32_value = {};
+   positive_enum enum_value = zero;
 
-   using serialize = zpp::bits::pb_members<2>;
+   using serialize = sysio::pb_members<2>;
+   serialize use();
+};
+
+struct protobuf_repeated_int32_values {
+   std::vector<sysio::pb_int32> values = {};
+
+   using serialize = sysio::pb_members<1>;
    serialize use();
 };
 
@@ -70,54 +77,91 @@ static void check_bytes(const std::vector<char>& actual, const std::array<unsign
    }
 }
 
-template <typename Message, std::size_t Size>
-static void check_int_value(int64_t value, const std::array<unsigned char, Size>& expected) {
-   Message original;
+template <std::size_t Size>
+static void check_int32_value(int32_t value, const std::array<unsigned char, Size>& expected) {
+   protobuf_int32_value original;
    original.value = value;
 
    const auto actual = encode(original);
    check_bytes(actual, expected);
 
-   Message decoded;
+   protobuf_int32_value decoded;
+   CHECK_EQUAL(decode(actual, decoded), std::errc{})
+   CHECK_EQUAL(static_cast<int32_t>(decoded.value), value)
+}
+
+template <std::size_t Size>
+static void check_int64_value(int64_t value, const std::array<unsigned char, Size>& expected) {
+   protobuf_int64_value original;
+   original.value = value;
+
+   const auto actual = encode(original);
+   check_bytes(actual, expected);
+
+   protobuf_int64_value decoded;
    CHECK_EQUAL(decode(actual, decoded), std::errc{})
    CHECK_EQUAL(static_cast<int64_t>(decoded.value), value)
 }
 
 SYSIO_TEST_BEGIN(protobuf_int32_boundary_wire_test)
-   check_int_value<protobuf_int32_value>(0, std::array<unsigned char, 3>{0x02, 0x08, 0x00});
-   check_int_value<protobuf_int32_value>(1, std::array<unsigned char, 3>{0x02, 0x08, 0x01});
-   check_int_value<protobuf_int32_value>(42, std::array<unsigned char, 3>{0x02, 0x08, 0x2a});
-   check_int_value<protobuf_int32_value>(
+   CHECK_EQUAL(sizeof(sysio::pb_int32), sizeof(int32_t))
+
+   check_int32_value(0, std::array<unsigned char, 3>{0x02, 0x08, 0x00});
+   check_int32_value(1, std::array<unsigned char, 3>{0x02, 0x08, 0x01});
+   check_int32_value(42, std::array<unsigned char, 3>{0x02, 0x08, 0x2a});
+   check_int32_value(
       std::numeric_limits<int32_t>::max(),
       std::array<unsigned char, 7>{0x06, 0x08, 0xff, 0xff, 0xff, 0xff, 0x07});
-   check_int_value<protobuf_int32_value>(
+   check_int32_value(
       -1,
       std::array<unsigned char, 12>{0x0b, 0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                                     0xff, 0xff, 0xff, 0x01});
-   check_int_value<protobuf_int32_value>(
+   check_int32_value(
       std::numeric_limits<int32_t>::min(),
       std::array<unsigned char, 12>{0x0b, 0x08, 0x80, 0x80, 0x80, 0x80, 0xf8, 0xff,
                                     0xff, 0xff, 0xff, 0x01});
 SYSIO_TEST_END
 
+SYSIO_TEST_BEGIN(protobuf_repeated_int32_wire_test)
+   protobuf_repeated_int32_values value;
+   value.values = {1, -1};
+
+   const auto actual = encode(value);
+
+   const std::array<unsigned char, 14> expected = {
+      0x0d,
+      0x0a, 0x0b, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+   };
+
+   check_bytes(actual, expected);
+
+   protobuf_repeated_int32_values decoded;
+   CHECK_EQUAL(decode(actual, decoded), std::errc{})
+   CHECK_EQUAL(decoded.values.size(), static_cast<std::size_t>(2))
+   if (decoded.values.size() == 2) {
+      CHECK_EQUAL(static_cast<int32_t>(decoded.values[0]), 1)
+      CHECK_EQUAL(static_cast<int32_t>(decoded.values[1]), -1)
+   }
+SYSIO_TEST_END
+
 SYSIO_TEST_BEGIN(protobuf_int64_negative_wire_test)
-   check_int_value<protobuf_int64_value>(
+   check_int64_value(
       -2,
       std::array<unsigned char, 12>{0x0b, 0x08, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff,
                                     0xff, 0xff, 0xff, 0x01});
 SYSIO_TEST_END
 
-SYSIO_TEST_BEGIN(protobuf_negative_enum_wire_test)
+SYSIO_TEST_BEGIN(protobuf_int32_and_enum_wire_test)
    protobuf_negative_values value;
    value.int32_value = -1;
-   value.enum_value = negative;
+   value.enum_value = positive;
 
    const auto actual = encode(value);
 
-   const std::array<unsigned char, 23> expected = {
-      0x16,
+   const std::array<unsigned char, 14> expected = {
+      0x0d,
       0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
-      0x10, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+      0x10, 0x2a,
    };
 
    check_bytes(actual, expected);
@@ -125,7 +169,7 @@ SYSIO_TEST_BEGIN(protobuf_negative_enum_wire_test)
    protobuf_negative_values decoded;
    CHECK_EQUAL(decode(actual, decoded), std::errc{})
    CHECK_EQUAL(static_cast<int64_t>(decoded.int32_value), -1)
-   CHECK_EQUAL(decoded.enum_value, negative)
+   CHECK_EQUAL(decoded.enum_value, positive)
 SYSIO_TEST_END
 
 int main(int argc, char** argv) {
@@ -136,7 +180,8 @@ int main(int argc, char** argv) {
    silence_output(!verbose);
 
    SYSIO_TEST(protobuf_int32_boundary_wire_test);
+   SYSIO_TEST(protobuf_repeated_int32_wire_test);
    SYSIO_TEST(protobuf_int64_negative_wire_test);
-   SYSIO_TEST(protobuf_negative_enum_wire_test);
+   SYSIO_TEST(protobuf_int32_and_enum_wire_test);
    return has_failed();
 }

--- a/tests/unit/test_contracts/pb_tests.cpp
+++ b/tests/unit/test_contracts/pb_tests.cpp
@@ -15,7 +15,7 @@ public:
       sysio::check(msg.note == "hello", "validate msg.note");
 
       ActResult result;
-      result.value = zpp::bits::vint64_t(42);
+      result.value = 42;
       result.str_value = "result_string";
       return result;
    }

--- a/tools/protoc-gen-zpp/protoc-gen-zpp.cpp
+++ b/tools/protoc-gen-zpp/protoc-gen-zpp.cpp
@@ -187,9 +187,19 @@ struct zpp_generator {
 
    void generate_enum(const gpb::EnumDescriptor* descriptor, std::stringstream& strm, std::string indent = "") {
       auto name = reserve_keyword(sv2s(descriptor->name()));
-      strm << indent << "enum " << name << " : int64_t {\n";
-      int min_value = descriptor->value(0)->number();
-      int max_value = descriptor->value(0)->number();
+      int max_value = 0;
+
+      for (int i = 0; i < descriptor->value_count(); ++i) {
+         auto value = descriptor->value(i);
+         if (value->number() < 0) {
+            response.set_error("negative protobuf enum values are not supported: " +
+                               sv2s(descriptor->full_name()) + "." + sv2s(value->name()));
+            return;
+         }
+         max_value = std::max(max_value, value->number());
+      }
+
+      strm << indent << "enum " << name << " : int32_t {\n";
 
       if (descriptor->value_count()) {
          for (int i = 0; i < descriptor->value_count(); ++i) {
@@ -200,18 +210,16 @@ struct zpp_generator {
             if (descriptor->options().deprecated())
                strm << " [[deprecated]]";
             strm << " = " << value->number();
-            min_value = std::min(min_value, value->number());
-            max_value = std::max(max_value, value->number());
          }
       }
       strm << "\n" << indent << "};\n\n";
 
-      if (min_value < -128 || max_value > 128 || (max_value - min_value) > UINT16_MAX) {
+      if (max_value > 128) {
          epilogue_strm << "\n"
                        << "template <>\n"
                        << "struct magic_enum::customize::enum_range<" << full_name_to_cpp_name(descriptor->full_name())
                        << "> {\n"
-                       << "   static constexpr int min = " << min_value << ";\n"
+                       << "   static constexpr int min = 0;\n"
                        << "   static constexpr int max = " << max_value << ";\n"
                        << "};\n";
       }
@@ -223,7 +231,7 @@ struct zpp_generator {
       bool can_be_optional = true;
 
       switch (descriptor->type()) {
-      case gpb::FieldDescriptor::TYPE_INT32: result = "zpp::bits::vint64_t"; break;
+      case gpb::FieldDescriptor::TYPE_INT32: result = "sysio::pb_int32"; break;
       case gpb::FieldDescriptor::TYPE_INT64: result = "zpp::bits::vint64_t"; break;
       case gpb::FieldDescriptor::TYPE_UINT32: result = "zpp::bits::vuint32_t"; break;
       case gpb::FieldDescriptor::TYPE_UINT64: result = "zpp::bits::vuint64_t"; break;
@@ -315,7 +323,7 @@ struct zpp_generator {
 
       strm << indent << "struct " << message_name << " {\n";
 
-      for (size_t i = 0; i < descriptor->enum_type_count(); ++i)
+      for (size_t i = 0; i < descriptor->enum_type_count() && !response.has_error(); ++i)
          generate_enum(descriptor->enum_type(i), strm, indent + "   ");
 
       for (size_t i = 0; i < descriptor->nested_type_count(); ++i) {
@@ -332,7 +340,7 @@ struct zpp_generator {
 
       // Emit the serialize protocol declaration for zpp_bits protobuf support
       if (info.pb_map.size()) {
-         strm << indent << "   using serialize = zpp::bits::protocol<zpp::bits::pb{\n";
+         strm << indent << "   using serialize = zpp::bits::protocol<sysio::pb_protocol{\n";
          int i = 0;
          for (auto [index, field_number] : info.pb_map) {
             if (i++ != 0)
@@ -342,7 +350,7 @@ struct zpp_generator {
          strm << "}, " << descriptor->field_count() << ">;\n";
       } else {
          // No field remapping needed, use default pb protocol
-         strm << indent << "   using serialize = zpp::bits::pb_members<" << descriptor->field_count() << ">;\n";
+         strm << indent << "   using serialize = sysio::pb_members<" << descriptor->field_count() << ">;\n";
       }
 
       if (descriptor->field_count()) {
@@ -419,6 +427,7 @@ struct zpp_generator {
       }
 
       strm << "#include <zpp_bits.h>\n"
+           << "#include <sysio/pb.hpp>\n"
            << "#include <magic_enum/magic_enum.hpp>\n"
            << "// @@protoc_insertion_point(includes)\n";
 
@@ -428,7 +437,7 @@ struct zpp_generator {
          strm << "namespace " << ns << " {\n";
       }
 
-      for (int i = 0; i < proto_file->enum_type_count(); ++i)
+      for (int i = 0; i < proto_file->enum_type_count() && !response.has_error(); ++i)
          generate_enum(proto_file->enum_type(i), strm, indent);
 
       std::map<const gpb::Descriptor*, const gpb::Descriptor*>    dependencies;
@@ -440,6 +449,10 @@ struct zpp_generator {
 
       for (auto [_, msg] : messages) {
          strm << msg;
+      }
+
+      if (response.has_error()) {
+         return;
       }
 
       if (ns.size()) {
@@ -461,6 +474,9 @@ int main(int argc, const char** argv) {
 
    for (int i = 0; i < request.file_to_generate_size(); ++i) {
       generator.generate_file(request.file_to_generate(i));
+      if (generator.response.has_error()) {
+         break;
+      }
    }
 
    generator.response.SerializePartialToOstream(&std::cout);


### PR DESCRIPTION
## Summary
- add sysio::pb_int32 with int32_t storage and protobuf-compatible signed varint encoding
- generate protobuf int32 fields as sysio::pb_int32 while keeping enums int32_t and rejecting negative enum values
- add wire tests for int32 boundary values, repeated packed int32 values, and enum/int32 behavior
- document protobuf integer wrapper behavior

## Testing
- git diff --check
- standalone packed repeated pb_int32 wire probe
- g++ -std=c++20 -fsyntax-only ... tests/unit/protobuf_wire_tests.cpp (host compiler emits existing ignored sysio_wasm_import warnings)
