### PR TITLE
Reject negative protobuf enum values

### DIFF
--- a/docs/protocol-buffers.md
+++ b/docs/protocol-buffers.md
@@ -239,7 +239,7 @@ The `pb_members<N>` declaration (where N is the number of fields) enables protob
 | `bool` | `bool` |
 | `string` | `std::string` |
 | `bytes` | `std::vector<char>` |
-| `enum` | C++ `enum : int64_t` |
+| `enum` | C++ `enum : int32_t` |
 | `message` | C++ `struct` |
 | `repeated T` | `std::vector<T>` |
 | `map<K,V>` | `std::map<K,V>` |
@@ -249,5 +249,6 @@ The `pb_members<N>` declaration (where N is the number of fields) enables protob
 - Only proto3 syntax is supported
 - `oneof` fields are not supported
 - `std::optional` fields (`[(zpp.zpp_optional) = true]`) are not supported — stock `zpp_bits` does not support optional fields in protobuf serialization mode
+- Negative enum values are not supported
 - Unpacked repeated fields are not supported
 - WASM contracts have no exception support; serialization errors abort via `sysio::check()`

--- a/tests/unit/protobuf_wire_tests.cpp
+++ b/tests/unit/protobuf_wire_tests.cpp
@@ -13,9 +13,9 @@
 #include <sysio/tester.hpp>
 #include <zpp_bits.h>
 
-enum negative_enum : int64_t {
+enum positive_enum : int32_t {
    zero = 0,
-   negative = -1,
+   positive = 42,
 };
 
 struct protobuf_int32_value {
@@ -32,9 +32,9 @@ struct protobuf_int64_value {
    serialize use();
 };
 
-struct protobuf_negative_values {
+struct protobuf_int32_and_enum_values {
    zpp::bits::vint64_t int32_value = {};
-   negative_enum enum_value = zero;
+   positive_enum enum_value = zero;
 
    using serialize = zpp::bits::pb_members<2>;
    serialize use();
@@ -107,25 +107,25 @@ SYSIO_TEST_BEGIN(protobuf_int64_negative_wire_test)
                                     0xff, 0xff, 0xff, 0x01});
 SYSIO_TEST_END
 
-SYSIO_TEST_BEGIN(protobuf_negative_enum_wire_test)
-   protobuf_negative_values value;
+SYSIO_TEST_BEGIN(protobuf_int32_and_enum_wire_test)
+   protobuf_int32_and_enum_values value;
    value.int32_value = -1;
-   value.enum_value = negative;
+   value.enum_value = positive;
 
    const auto actual = encode(value);
 
-   const std::array<unsigned char, 23> expected = {
-      0x16,
+   const std::array<unsigned char, 14> expected = {
+      0x0d,
       0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
-      0x10, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01,
+      0x10, 0x2a,
    };
 
    check_bytes(actual, expected);
 
-   protobuf_negative_values decoded;
+   protobuf_int32_and_enum_values decoded;
    CHECK_EQUAL(decode(actual, decoded), std::errc{})
    CHECK_EQUAL(static_cast<int64_t>(decoded.int32_value), -1)
-   CHECK_EQUAL(decoded.enum_value, negative)
+   CHECK_EQUAL(decoded.enum_value, positive)
 SYSIO_TEST_END
 
 int main(int argc, char** argv) {
@@ -137,6 +137,6 @@ int main(int argc, char** argv) {
 
    SYSIO_TEST(protobuf_int32_boundary_wire_test);
    SYSIO_TEST(protobuf_int64_negative_wire_test);
-   SYSIO_TEST(protobuf_negative_enum_wire_test);
+   SYSIO_TEST(protobuf_int32_and_enum_wire_test);
    return has_failed();
 }

--- a/tools/protoc-gen-zpp/protoc-gen-zpp.cpp
+++ b/tools/protoc-gen-zpp/protoc-gen-zpp.cpp
@@ -187,9 +187,19 @@ struct zpp_generator {
 
    void generate_enum(const gpb::EnumDescriptor* descriptor, std::stringstream& strm, std::string indent = "") {
       auto name = reserve_keyword(sv2s(descriptor->name()));
-      strm << indent << "enum " << name << " : int64_t {\n";
-      int min_value = descriptor->value(0)->number();
-      int max_value = descriptor->value(0)->number();
+      int max_value = 0;
+
+      for (int i = 0; i < descriptor->value_count(); ++i) {
+         auto value = descriptor->value(i);
+         if (value->number() < 0) {
+            response.set_error("negative protobuf enum values are not supported: " +
+                               sv2s(descriptor->full_name()) + "." + sv2s(value->name()));
+            return;
+         }
+         max_value = std::max(max_value, value->number());
+      }
+
+      strm << indent << "enum " << name << " : int32_t {\n";
 
       if (descriptor->value_count()) {
          for (int i = 0; i < descriptor->value_count(); ++i) {
@@ -200,18 +210,18 @@ struct zpp_generator {
             if (descriptor->options().deprecated())
                strm << " [[deprecated]]";
             strm << " = " << value->number();
-            min_value = std::min(min_value, value->number());
-            max_value = std::max(max_value, value->number());
          }
       }
       strm << "\n" << indent << "};\n\n";
 
-      if (min_value < -128 || max_value > 128 || (max_value - min_value) > UINT16_MAX) {
+      /// Extend magic_enum's default range when non-negative protobuf enum
+      /// values exceed its built-in scan limit.
+      if (max_value > 128) {
          epilogue_strm << "\n"
                        << "template <>\n"
                        << "struct magic_enum::customize::enum_range<" << full_name_to_cpp_name(descriptor->full_name())
                        << "> {\n"
-                       << "   static constexpr int min = " << min_value << ";\n"
+                       << "   static constexpr int min = 0;\n"
                        << "   static constexpr int max = " << max_value << ";\n"
                        << "};\n";
       }
@@ -315,7 +325,7 @@ struct zpp_generator {
 
       strm << indent << "struct " << message_name << " {\n";
 
-      for (size_t i = 0; i < descriptor->enum_type_count(); ++i)
+      for (size_t i = 0; i < descriptor->enum_type_count() && !response.has_error(); ++i)
          generate_enum(descriptor->enum_type(i), strm, indent + "   ");
 
       for (size_t i = 0; i < descriptor->nested_type_count(); ++i) {


### PR DESCRIPTION
## Summary
- keep protobuf `int32` fields mapped to `zpp::bits::vint64_t`
- generate protobuf enums as `enum : int32_t`
- reject negative protobuf enum values during `cdt-protoc-gen-zpp` generation
- update protobuf wire tests and docs for the supported enum range

Replaces #85, which explored a dedicated `sysio::pb_int32` wrapper.

## Tests
- `cmake --build build --target cdt-protoc-gen-zpp CDTWasmTests -- -j6`
- `./build/tests/unit/protobuf_wire_tests`
- downstream experiment in `wire-sysio`: `./build/codex-system-contracts/contracts/tests/contracts_unit_test -- --sys-vm` passed with 312 test cases
