### PR TITLE
codegen: fix parallel-build race that aborts with jsoncons::parse_error

### DIFF
--- a/tools/codegen/cdt-codegen.cpp
+++ b/tools/codegen/cdt-codegen.cpp
@@ -56,6 +56,41 @@ static bool exists(const char* filename) {
    return stat(filename, &st) == 0;
 }
 
+// Atomically replace `filename` with `content`: write to a unique per-process
+// temp file in the same directory, then rename(2) over the target. Under a
+// parallel build, many cdt-codegen processes (one per translation unit) write
+// the same shared per-contract outputs -- <contract>.abi and, in link mode,
+// <contract>.dispatch.cpp. A plain truncate+write lets those concurrent writes
+// interleave and leave a corrupt file for whoever consumes it, and the in-place
+// truncate also momentarily exposes an empty/partial file to a concurrent
+// reader. rename(2) is atomic within a directory, so each publish is
+// all-or-nothing: a concurrent reader always sees one complete version, and the
+// last writer wins cleanly instead of corrupting the file. Returns false (and
+// removes the temp) on any I/O error.
+static bool write_file_atomic(const std::string& filename, const std::string& content) {
+   const std::string tmp = filename + ".tmp." + std::to_string((long)getpid());
+   {
+      std::ofstream ofs(tmp);
+      if (!ofs) {
+         std::cerr << "cannot open " + tmp + "\n";
+         return false;
+      }
+      ofs << content;
+      ofs.close();
+      if (!ofs) { // a flush/close error must not publish a truncated file
+         std::cerr << "failed writing " + tmp + "\n";
+         unlink(tmp.c_str());
+         return false;
+      }
+   }
+   if (rename(tmp.c_str(), filename.c_str()) != 0) {
+      std::cerr << "cannot publish " + filename + "\n";
+      unlink(tmp.c_str());
+      return false;
+   }
+   return true;
+}
+
 // Write dispatch code (apply entry point) to an output stream.
 // When weak=true, apply() gets __attribute__((weak)) so a user-defined apply()
 // (e.g. from SYSIO_DISPATCH) takes priority at link time.
@@ -141,17 +176,14 @@ static void write_sysio_dispatch(std::ostream& ofs, const std::set<wasm_action>&
 static void generate_sysio_dispatch(const std::string& output, const std::set<wasm_action>& wasm_actions,
                                     const std::set<wasm_notify>& wasm_notifies,
                                     bool has_pre_dispatch, bool has_post_dispatch) {
-   try {
-      std::ofstream ofs(output);
-      if (!ofs)
-         throw std::runtime_error("cannot open " + output);
-      ofs << "#include <cstdint>\n"
-          << "#include <sysio/name.hpp>\n";
-      write_sysio_dispatch(ofs, wasm_actions, wasm_notifies, false, has_pre_dispatch, has_post_dispatch);
-      ofs.close();
-   } catch (...) {
+   std::stringstream ss;
+   ss << "#include <cstdint>\n"
+      << "#include <sysio/name.hpp>\n";
+   write_sysio_dispatch(ss, wasm_actions, wasm_notifies, false, has_pre_dispatch, has_post_dispatch);
+   // Atomic publish: in link mode every parallel TU writes this same
+   // <contract>.dispatch.cpp; a plain truncate+write would let them corrupt it.
+   if (!write_file_atomic(output, ss.str()))
       std::cerr << "Failed to generate sysio dispatcher\n";
-   }
 }
 
 static std::vector<std::string> split_then_prepend(const std::string& s, char delim, std::string prefix) {
@@ -666,18 +698,16 @@ int main(int argc, const char** argv) {
                return -1;
             }
 
-            std::string   filename = abi_output_path.empty()
-                                   ? output_dir + "/" + contract_name + ".abi"
-                                   : abi_output_path;
-            std::ofstream ofs(filename);
-            if (!ofs) {
-               std::cerr << "cannot open " + filename + "\n";
-               return -1;
-            }
+            std::string filename = abi_output_path.empty()
+                                 ? output_dir + "/" + contract_name + ".abi"
+                                 : abi_output_path;
             std::stringstream abi_json;
             abi_json << pretty_print(abi);
-            ofs << abi_json.str();
-            ofs.close();
+            // Atomic publish: many parallel TUs write this same <contract>.abi;
+            // a plain truncate+write would let them interleave into a corrupt file.
+            if (!write_file_atomic(filename, abi_json.str())) {
+               return -1;
+            }
          }
       }
 

--- a/tools/codegen/cdt-codegen.cpp
+++ b/tools/codegen/cdt-codegen.cpp
@@ -423,21 +423,32 @@ static void gen_actions(const std::string& input) {
    auto basename = input.substr(input.rfind('/') + 1);
    auto desc_file = output_dir + "/" + contract_name + "." + basename + ".desc";
    if (exists(raw_desc.c_str())) {
-      rename(raw_desc.c_str(), desc_file.c_str());
       // Stamp the originating source path into the .desc so a later build can
       // detect it is stale when the source .cpp has been removed or moved.
       // Without this marker, a stale .desc gets merged into the contract ABI
       // and produces "ABI structs malformed : <name> already defined" errors.
       // Only attempt the JSON round-trip when abigen actually produced content;
       // a failed abigen run leaves an empty .desc that ojson::parse would reject.
-      if (file_size(desc_file.c_str()) > 0) {
-         std::ifstream ifs(desc_file);
+      //
+      // Crucially, stamp raw_desc -- the abigen plugin's private, un-prefixed
+      // output -- and ONLY THEN atomically rename it to the contract-prefixed
+      // desc_file that sibling TUs discover via the output-dir scan below.
+      // rename(2) is atomic within a directory, so a concurrent parallel
+      // cdt-codegen process always observes either the old or the new complete
+      // file, never a half-written one. (Previously the rename happened first and
+      // the stamp truncated and rewrote the already-published desc_file in place;
+      // a concurrent merge scan reading it mid-rewrite saw partial JSON and
+      // aborted the whole build with an uncaught jsoncons::parse_error.)
+      if (file_size(raw_desc.c_str()) > 0) {
+         std::ifstream ifs(raw_desc);
          auto desc = ojson::parse(ifs);
          ifs.close();
          desc["____source_file"] = input;
-         std::ofstream ofs(desc_file);
+         std::ofstream ofs(raw_desc);
          ofs << desc.to_string();
+         ofs.close();
       }
+      rename(raw_desc.c_str(), desc_file.c_str());
       desc_files.push_back(desc_file);
    }
 }
@@ -696,7 +707,12 @@ int main(int argc, const char** argv) {
          }
       }
       return 0;
-   } catch (std::runtime_error& err) {
+   } catch (const std::exception& err) {
+      // Catch std::exception, not just std::runtime_error: jsoncons::parse_error
+      // derives from std::exception but NOT from std::runtime_error, so a parse
+      // failure that reaches here (e.g. a malformed/empty .desc) must still surface
+      // as a clean diagnostic and a non-zero exit rather than an uncaught exception
+      // that calls std::terminate ("terminate called after throwing ...").
       std::cerr << err.what() << '\n';
       return -1;
    }


### PR DESCRIPTION
## Fix the parallel-build race that aborts contract builds with `jsoncons::parse_error`

### Symptom
Intermittent, non-deterministic contract-build failure:

```
terminate called after throwing an instance of 'jsoncons::parse_error'
```

Seen most often on contracts with many translation units (e.g. `sysio.system`). Retrying the build usually "fixes" it — the hallmark of a race.

### Root cause
`cdt-codegen` runs **one process per translation unit, concurrently, in a shared output directory**. Each process:

1. renames its abigen output to the contract-prefixed, directory-scanned name `<contract>.<tu>.desc`, then
2. **truncates and rewrites that already-published `.desc` in place** (`std::ofstream ofs(desc_file)`) to stamp `____source_file`.

Meanwhile every sibling process scans the directory and `ojson::parse`s each `.desc` to merge the contract ABI. If a sibling reads a `.desc` during step 2's truncate→rewrite window, it parses an empty or half-written file and `ojson::parse` throws `jsoncons::parse_error`.

That exception derives from `std::exception` but **not** from `std::runtime_error`, so the only handler in `main()` —

```cpp
} catch (std::runtime_error& err) { ... }
```

— never catches it. It propagates out of `main` and calls `std::terminate`, aborting the whole build.

### Fix
1. **Atomic publish.** Stamp the private, un-prefixed `raw_desc` (which no sibling discovers via the directory scan) **before** the rename, then publish it with a single atomic `rename(2)`. A concurrent reader now always observes either the old or the new complete file, never a partial one.
2. **Correct catch.** Broaden the top-level handler from `std::runtime_error` to `const std::exception&`, so any residual parse failure (e.g. a genuinely malformed `.desc`) surfaces as a clean diagnostic and a non-zero exit instead of `std::terminate`.

The change only affects *when/how* the `.desc` is written (timing/atomicity); generated `.abi`/`.wasm` content is unchanged.

### Validation
- **Standalone reproduction** of the exact read/rewrite pattern against the vendored jsoncons: **106,218 parse failures / 150,000 reads** with the in-place truncate-rewrite → **0** with the atomic rename. (`std::is_base_of` confirms `parse_error` is a `std::exception` but not a `std::runtime_error`, i.e. why the old catch missed it.)
- **Real contract build** (`sysio.system`, 13 TUs, `ninja -j16`, force-rerun loop): **5 crashes / 15 iterations before** the fix, **0 / 15 after**.
- Full `contracts_project` build is clean.

### Second commit: atomically publish `.abi` and `.dispatch.cpp` too
The same parallel model has a related latent race: every TU's `cdt-codegen` also writes the shared per-contract `<contract>.abi` (and, in link mode, `<contract>.dispatch.cpp`) with a plain truncate+write, so concurrent writers can interleave into a corrupt file and a concurrent reader can see a partial one. The second commit adds a `write_file_atomic(filename, content)` helper (unique temp file + atomic `rename(2)`) and routes both shared writes through it. The per-TU `.actions.cpp` append is left alone — each process appends only to its own file, so there's no cross-process race there.

Generated content is unchanged: validated **byte-identical** for `sysio.roa.abi` and **semantically identical** (same structs/actions/tables, equal when sorted) for `sysio.system.abi`. The `sysio.system` stress loop stayed 10/10 clean with no leaked temp files.

### ABI merge order — already handled on `develop`
`sysio.system.abi`'s struct/action/table **ordering** also varies between full rebuilds because the ABI merge consumes `.desc` files in directory-scan (`readdir`) order — a separate, pre-existing reproducibility wrinkle, independent of the write races fixed here. No action needed in this PR: `develop` already makes the merge deterministic (`std::sort` + de-dup of `desc_files`), and that reaches `master` when `develop` merges.

### Branch note
Targets `master`. `develop` does **not** carry this crash fix — its only `cdt-codegen.cpp` change versus `master` is the merge-order sort noted above — so the `.desc`, `.abi`, and catch regions changed here don't overlap `develop`, and this PR merges cleanly under a later `develop` → `master` merge.
