### PR TITLE
codegen: deterministic ABI merge order (sort .desc files before merge)

### DIFF
--- a/tools/codegen/cdt-codegen.cpp
+++ b/tools/codegen/cdt-codegen.cpp
@@ -3,6 +3,7 @@
 #include <sysio/abimerge.hpp>
 #include <sysio/whereami/whereami.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <set>
@@ -481,6 +482,16 @@ int main(int argc, const char** argv) {
             closedir(dir);
          }
       }
+
+      // Merge the .desc files in a stable, path-sorted order. readdir(3) returns
+      // directory entries in an arbitrary, filesystem-dependent order, and each
+      // parallel cdt-codegen process seeds desc_files with its OWN translation
+      // unit first, so without this sort the merged ABI's struct/action/table
+      // order varies between rebuilds and between the per-TU processes that all
+      // write the shared <contract>.abi. Sorting by path makes every process
+      // produce a byte-identical ABI -- reproducible output regardless of
+      // readdir order or which TU wins the (now atomic) .abi write.
+      std::sort(desc_files.begin(), desc_files.end());
 
       ojson abi;
 


### PR DESCRIPTION
## Make ABI generation reproducible (deterministic `.desc` merge order)

### Problem
`cdt-codegen` builds the contract ABI by merging the per-translation-unit `<contract>.<tu>.desc` files, but it consumes them in **`readdir(3)` order** — which is filesystem-dependent and arbitrary. Each parallel `cdt-codegen` process also seeds its `desc_files` list with **its own TU first**. As a result, the merged `<contract>.abi`'s struct/action/table **ordering varies** between otherwise-identical builds (and between the per-TU processes that all write the shared `.abi`). Same contract, same sources → different ABI bytes, hence a different embedded ABI / `.wasm` and a different contract ABI hash. That defeats reproducible builds.

This is a real, observed effect: on `sysio.system`, two full rebuilds produced semantically-identical but byte-different `.abi` files purely due to element order.

### Fix
Sort `desc_files` by path immediately after the output-directory scan and before the merge loop. Every process, on every build, then merges in the same order and emits a byte-identical ABI — regardless of `readdir` order or which TU process wins the `.abi` write.

```cpp
std::sort(desc_files.begin(), desc_files.end());
```

(+ `#include <algorithm>`.)

### Validation
On `sysio.system`, **4 full rebuilds with the `.desc` files deleted between runs** (to force fresh inodes / different `readdir` order) now produce a **byte-identical** `sysio.system.abi` (same md5 all four times). The ABI is **semantically unchanged** from before (same structs/actions/tables; only the order is now stable).

### Relationship to #92
Independent of the parallel-build write-race fixes in #92 — different region of the same file, no textual conflict. Can be reviewed/merged in either order.
