### PR TITLE
codegen: serialize per-contract codegen for complete ABI/dispatch (follow-up to #92)

### DIFF
--- a/tools/codegen/cdt-codegen.cpp
+++ b/tools/codegen/cdt-codegen.cpp
@@ -8,7 +8,9 @@
 #include <set>
 #include <sstream>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/file.h>
 #include <dirent.h>
 #include <llvm/Support/Program.h>
 
@@ -493,6 +495,27 @@ int main(int argc, const char** argv) {
    bool                  has_post_dispatch    = false;
 
    parse_args(argc, argv);
+
+   // Serialize cdt-codegen across the parallel translation units of one contract.
+   // The build runs one process per TU concurrently in a shared output_dir, and
+   // every process re-scans that dir and republishes the shared <contract>.abi /
+   // dispatch from whatever .desc files it happened to see at scan time. Holding a
+   // per-contract advisory lock for the whole run makes those processes run one at
+   // a time, so the LAST one observes every sibling's .desc and publishes a
+   // COMPLETE ABI/dispatch. This closes the stale-snapshot completeness race -- a
+   // late process atomically replacing a complete ABI with a partial one -- that an
+   // atomic write alone cannot. The lock is advisory (flock); the kernel drops it
+   // when this process exits, including on crash. Best-effort: if the lock file
+   // cannot be created (e.g. a read-only output_dir) we proceed unlocked rather
+   // than fail the build -- the atomic writes still prevent torn output, we only
+   // lose the completeness guarantee in that unusual case.
+   int codegen_lock_fd = -1;
+   if (!contract_name.empty()) {
+      const std::string lock_path = output_dir + "/." + contract_name + ".codegen.lock";
+      codegen_lock_fd = open(lock_path.c_str(), O_CREAT | O_RDWR, 0644);
+      if (codegen_lock_fd >= 0)
+         flock(codegen_lock_fd, LOCK_EX); // held for the whole run; released on exit
+   }
 
    try {
       for (auto& input : input_files) {


### PR DESCRIPTION
## Serialize per-contract codegen so the published ABI/dispatch is always complete

Follow-up to #92, addressing @huangminghuang's review comment there: the atomic `.desc`/`.abi` writes in #92 stop *torn/partial* reads and writes, but they don't close the **stale-snapshot completeness race**. Each per-TU `cdt-codegen` process builds the shared `<contract>.abi` (and dispatch) from whatever `.desc` files it happened to see during its directory scan, so a process that scanned an incomplete set can atomically replace a *complete* ABI with a *partial* one — and the same applies to the generated dispatch.

**Stacked on #92** (base `fix/cdt-codegen-desc-race`); the diff here is just the serialization commit. Re-targets to `master` once #92 merges.

### Fix
Hold a per-contract advisory lock (`flock` on `<output_dir>/.<contract>.codegen.lock`) for the whole `cdt-codegen` run, so the per-TU processes execute one at a time. By the time the last process runs, every sibling has already written its `.desc`, so it observes the complete set and publishes a complete, deterministic ABI/dispatch. This is the *serialization step* option from the review thread, and it closes the gap for **both** the ABI and the dispatch (the dispatch isn't a mergeable object, so an in-process ABI-only merge wouldn't have covered it).

- Keyed per contract (`output_dir` + `contract_name`), so **different contracts still build in parallel**; only the TUs within one contract serialize.
- Advisory, and released by the kernel on process exit (including on crash).
- Best-effort: if the lock file can't be created (e.g. a read-only `output_dir`), it proceeds unlocked — the #92 atomic writes still prevent torn output, only the completeness guarantee is lost in that unusual case.

### Perf
Serializes the per-contract codegen, including the clang compile (it's the same invocation). Cross-contract parallelism is preserved, so the wall-clock cost is bounded by the largest single contract; a full `contracts_project` build stayed ~flat (25s here). One caveat of the `flock` approach: under a high `-j`, the build may *launch* sibling `cdt-codegen` processes that then block on the lock, occupying ninja job slots while they wait. If that's undesirable, the equivalent build-level mechanism is a **per-contract ninja job pool (`depth = 1`)**, which lets ninja schedule one at a time instead of launching-then-blocking — happy to switch to that if you'd prefer to keep `cdt-codegen` concurrency-agnostic.

### Validation
- **Lock is enforced:** a one-TU rebuild takes 3s normally; with the lock held externally for 8s it takes 12s — i.e. `cdt-codegen` blocks on the lock for the hold duration.
- **ABI is complete & unchanged:** `sysio.system.abi` = 50 actions / 101 structs / 22 tables, semantically identical to the pre-change ABI.
- Full `contracts_project` build clean, all 8 contract ABIs produced, no deadlock/stall.
