### PR TITLE
ci: auto-cancel superseded workflow runs

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -11,6 +11,14 @@ on:
       - develop
   workflow_dispatch:
 
+# A newer run for the same branch/PR cancels the in-progress one instead of
+# leaving multiple builds racing to completion. github.head_ref is the source
+# branch on pull_request events; it falls back to github.ref for push events so
+# each branch (or PR) collapses to a single live run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,14 @@ on:
       - develop
   workflow_dispatch:
 
+# A newer run for the same branch/PR cancels the in-progress one instead of
+# leaving multiple builds racing to completion. github.head_ref is the source
+# branch on pull_request events; it falls back to github.ref for push events so
+# each branch (or PR) collapses to a single live run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   # build-platforms publishes the container image to GHCR.
   packages: write


### PR DESCRIPTION
## Auto-cancel superseded CI runs

The `Build & Test` and `Build & Test macOS` workflows had no `concurrency` group, so every push to a branch spawned an independent run and the prior in-progress runs kept building to completion (burning runner minutes). Cancelling one run never stopped the others.

This adds a concurrency group to both workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```

- `github.head_ref` is the source branch on `pull_request` events; it falls back to `github.ref` for `push`, so each branch/PR collapses to a single live run.
- The workflow name in the group keeps the two workflows independent (a macOS run won't cancel the Linux run).
- A new push now auto-cancels the in-progress run for that branch/PR.

### Note
`cancel-in-progress: true` also applies to `master`/`release/*` pushes — if two land in quick succession the earlier build is cancelled (it's re-runnable). If you'd rather never interrupt those, we can scope cancellation to non-default refs. Separately, neither workflow sets `timeout-minutes`, so a stuck job can run up to the 6h default — happy to add a cap in a follow-up.
