### PR TITLE
ci: let a cancelled run actually stop the build job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,11 @@ jobs:
   build:
     name: Build & Test
     needs: [discover, build-platforms]
-    if: always() && needs.discover.result == 'success' && (needs.build-platforms.result == 'success' || needs.build-platforms.result == 'skipped')
+    # !cancelled() (not always()) so this job still runs when build-platforms is
+    # skipped, but a cancelled run actually stops it. always() makes the job run
+    # even when the workflow is cancelled, which is why cancelling left the build
+    # running to completion.
+    if: ${{ !cancelled() && needs.discover.result == 'success' && (needs.build-platforms.result == 'success' || needs.build-platforms.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Make a cancelled run actually stop the build

Cancelling a CDT workflow run doesn't stop the build — it keeps compiling to completion (e.g. run 28392183044 ran ~1.5h *after* being cancelled, consuming runner minutes).

**Cause:** the `build` job's condition uses `always()`:
```yaml
if: always() && needs.discover.result == 'success' && (...)
```
`always()` makes a job run **even when the workflow is cancelled** (documented GitHub Actions behavior), so a cancel request can't stop it.

**Fix:** use `!cancelled()` instead — it keeps the original intent (run even when `build-platforms` is *skipped*) but lets cancellation through:
```yaml
if: ${{ !cancelled() && needs.discover.result == 'success' && (needs.build-platforms.result == 'success' || needs.build-platforms.result == 'skipped') }}
```

This does **not** add any auto-cancel-on-push behavior — manual cancel simply works now. The `notification` jobs keep `always()` on purpose (they should still send a result when a run is cancelled), and they're quick. The macOS build job already has no `always()`, so it didn't need a change.

Note: the build jobs have no `timeout-minutes`, so a genuinely stuck build can still run up to the 6h default. Happy to add a cap in a follow-up if you give me a safe ceiling for the CDT build.
