### PR TITLE
Add Debian package artifacts and release publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,8 @@ jobs:
         platform: [ubuntu24]
     runs-on: ubuntu-24.04
     container: ${{fromJSON(needs.discover.outputs.p)[matrix.platform].image}}
+    env:
+      SHOULD_PACKAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.platform == 'ubuntu24' }}
     steps:
         - uses: actions/checkout@v5
           with:
@@ -131,13 +133,13 @@ jobs:
             fi
             ctest --test-dir build -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" --output-on-failure
         - name: Build Debian package
-          if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.platform == 'ubuntu24' }}
+          if: env.SHOULD_PACKAGE == 'true'
           working-directory: build/packages
           run: |
             bash ./generate_package.sh deb ubuntu-24.04 amd64
             ls -lh ./*.deb
         - name: Upload Debian package artifact
-          if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.platform == 'ubuntu24' }}
+          if: env.SHOULD_PACKAGE == 'true'
           uses: actions/upload-artifact@v7
           with:
             name: cdt_ubuntu_package_amd64

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,6 +130,21 @@ jobs:
               exit 1
             fi
             ctest --test-dir build -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" --output-on-failure
+        - name: Build Debian package
+          if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.platform == 'ubuntu24' }}
+          working-directory: build/packages
+          run: |
+            bash ./generate_package.sh deb ubuntu-24.04 amd64
+            ls -lh ./*.deb
+        - name: Upload Debian package artifact
+          if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.platform == 'ubuntu24' }}
+          uses: actions/upload-artifact@v7
+          with:
+            name: cdt_ubuntu_package_amd64
+            path: build/packages/*.deb
+            if-no-files-found: error
+            retention-days: 30
+            compression-level: 0
   notification:
     name: Send Notification
     needs: [discover, build-platforms, build]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,33 +1,98 @@
-name: Upload Release .deb
+name: Publish Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  eb:
-    name: Upload Release .deb
+  validate-tag:
+    name: Validate Release Tag
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+      version: ${{ steps.validate.outputs.version }}
+      target_sha: ${{ steps.validate.outputs.target_sha }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Validate tag
+        id: validate
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$tag' must match vX.X.X."
+            exit 1
+          fi
+
+          target_sha="$(git rev-parse HEAD^{commit})"
+          git fetch --force origin master:refs/remotes/origin/master
+          if ! git merge-base --is-ancestor "$target_sha" origin/master; then
+            echo "::error::Tag '$tag' points to $target_sha, which is not on origin/master."
+            exit 1
+          fi
+
+          major="$(sed -nE 's/^set\(VERSION_MAJOR ([0-9]+)\).*/\1/p' CMakeLists.txt)"
+          minor="$(sed -nE 's/^set\(VERSION_MINOR ([0-9]+)\).*/\1/p' CMakeLists.txt)"
+          patch="$(sed -nE 's/^set\(VERSION_PATCH ([0-9]+)\).*/\1/p' CMakeLists.txt)"
+          if [[ -z "$major" || -z "$minor" || -z "$patch" ]]; then
+            echo "::error::Unable to read CDT version from CMakeLists.txt."
+            exit 1
+          fi
+
+          version="${major}.${minor}.${patch}"
+          if [[ "${tag#v}" != "$version" ]]; then
+            echo "::error::Tag '$tag' does not match CMake version '$version'."
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: validate-tag
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
       actions: read
+      contents: write
     steps:
-      - name: Get cdt.deb
-        id: getter
+      - name: Download Debian package artifact
+        id: deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
-          file: cdt_.*_amd64.deb 
-          target: ${{github.sha}}
+          file: cdt_.*_amd64.deb
+          target: ${{ needs.validate-tag.outputs.target_sha }}
           artifact-name: cdt_ubuntu_package_amd64
           wait-for-exact-target: true
-      - run: |
-          curl -LsSf \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{github.token}}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          -H "Content-Type: application/octet-stream" \
-          --data-binary "@${{steps.getter.outputs.downloaded-file}}" \
-          "https://uploads.github.com/repos/${{github.repository}}/releases/${{github.event.release.id}}/assets?name=${{steps.getter.outputs.downloaded-file}}"
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.validate-tag.outputs.tag }}
+          DEB_FILE: ${{ steps.deb.outputs.downloaded-file }}
+        run: |
+          if [[ -z "$DEB_FILE" || ! -f "$DEB_FILE" ]]; then
+            echo "::error::No Debian package artifact was downloaded."
+            exit 1
+          fi
+
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" "$DEB_FILE" --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            # GitHub adds source zip and tar.gz archives automatically for tag releases.
+            gh release create "$TAG_NAME" "$DEB_FILE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG_NAME" \
+              --generate-notes \
+              --verify-tag
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v[0-9]*.[0-9]*.[0-9]*"
+      - "!v*-*"
 
 defaults:
   run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 project(cdt)
 
 set(VERSION_MAJOR 4)
-set(VERSION_MINOR 1)
-set(VERSION_PATCH 1)
+set(VERSION_MINOR 2)
+set(VERSION_PATCH 0)
 # set(VERSION_SUFFIX "") 
 
 if(VERSION_SUFFIX)

--- a/cmake/CDTMacros.cmake.in
+++ b/cmake/CDTMacros.cmake.in
@@ -383,7 +383,7 @@ function(target_add_protobuf TARGET)
     OUTPUT ${OUTPUT_HDRS}
     COMMAND cdt::protoc
     -I ${ADD_PROTOBUF_INPUT_DIRECTORY}
-    -I ${CMAKE_FIND_ROOT_PATH}/include
+    -I ${CDT_ROOT}/include
     --plugin=protoc-gen-zpp=$<TARGET_FILE:cdt::protoc-gen-zpp>
     --zpp_out
     ${OUTPUT_DIR}

--- a/cmake/CDTMacros.cmake.in
+++ b/cmake/CDTMacros.cmake.in
@@ -377,13 +377,25 @@ function(target_add_protobuf TARGET)
     file(MAKE_DIRECTORY ${OUTPUT_DIR})
   endif()
 
+  set(_cdt_protobuf_include_dir)
+  foreach(_cdt_protobuf_root IN LISTS CDT_ROOT CMAKE_FIND_ROOT_PATH)
+    if(IS_DIRECTORY "${_cdt_protobuf_root}/include" AND EXISTS "${_cdt_protobuf_root}/include/zpp/zpp_options.proto")
+      set(_cdt_protobuf_include_dir "${_cdt_protobuf_root}/include")
+      break()
+    endif()
+  endforeach()
+
+  if(NOT _cdt_protobuf_include_dir)
+    message(FATAL_ERROR "Unable to find CDT protobuf include directory containing zpp/zpp_options.proto")
+  endif()
+
   # GENERATE PROTOBUF HEADERS WITH CUSTOM COMMAND
   add_custom_command(
     COMMENT "Generating ${OUTPUT_HDRS} from ${INPUT_FILES}"
     OUTPUT ${OUTPUT_HDRS}
     COMMAND cdt::protoc
     -I ${ADD_PROTOBUF_INPUT_DIRECTORY}
-    -I ${CDT_ROOT}/include
+    -I ${_cdt_protobuf_include_dir}
     --plugin=protoc-gen-zpp=$<TARGET_FILE:cdt::protoc-gen-zpp>
     --zpp_out
     ${OUTPUT_DIR}

--- a/cmake/cdt-config.cmake.in
+++ b/cmake/cdt-config.cmake.in
@@ -1,4 +1,10 @@
 if(NOT CDT_ROOT OR NOT IS_DIRECTORY ${CDT_ROOT})
+  if(IS_DIRECTORY "@CDT_ROOT_DIR@")
+    set(CDT_ROOT "@CDT_ROOT_DIR@")
+  endif()
+endif()
+
+if(NOT CDT_ROOT OR NOT IS_DIRECTORY ${CDT_ROOT})
   get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
   get_filename_component(PARENT_NAME ${PARENT_DIR} NAME)
   set(PREFIX_CANDIDATES)

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -26,6 +26,8 @@ Architecture: ${ARCH}
 Homepage: ${URL} 
 Maintainer: ${EMAIL} 
 Description: ${DESC}" &> ${PROJECT}/DEBIAN/control
+chmod 755 ${PROJECT}/DEBIAN
+chmod 644 ${PROJECT}/DEBIAN/control
 cat ${PROJECT}/DEBIAN/control
 
 export PREFIX

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -68,12 +68,18 @@ create_symlink sysio-wasm2wast cdt-wasm2wast
 create_symlink sysio-wast2wasm cdt-wast2wasm
 create_symlink cdt-ar cdt-ar
 create_symlink cdt-abidiff cdt-abidiff
+create_symlink cdt-protoc cdt-protoc
+create_symlink cdt-protoc-gen-zpp cdt-protoc-gen-zpp
 create_symlink cdt-nm cdt-nm
 create_symlink cdt-objcopy cdt-objcopy
 create_symlink cdt-objdump cdt-objdump
 create_symlink cdt-ranlib cdt-ranlib
 create_symlink cdt-readelf cdt-readelf
 create_symlink cdt-strip cdt-strip
+
+find ${PREFIX} -type d -exec chmod 755 {} +
+find ${PREFIX} -type f -exec chmod a+r {} +
+find ${PREFIX}/bin ${CDT_PREFIX}/bin -type f -perm -u=x -exec chmod a+rx {} +
 
 echo "Generating Tarball $NAME.tar.gz..."
 tar -cvzf $NAME.tar.gz ./${PREFIX}/* || exit 1


### PR DESCRIPTION
## Summary
- fix Debian package contents so installed CDT exposes protobuf tools, CMake package files resolve the installed root, and package permissions are valid
- bump CDT package version to 4.2.0
- build and upload `cdt_ubuntu_package_amd64` for successful `master` push CI runs, with build/upload guarded by one shared package condition
- publish GitHub releases for strict `vX.X.X` tags by reusing the existing Debian artifact from the same `origin/master` commit; suffixed tags such as rc/dev tags do not trigger this workflow
- rely on GitHub source zip/tarball archives for tag releases
- resolve protobuf include lookup from `CDT_ROOT` or the build-tree toolchain root so build-tree tests and installed packages both find `zpp/zpp_options.proto`

## Validation
- `bash -n scripts/generate_deb.sh scripts/generate_tarball.sh scripts/generate_package.sh.in`
- `git diff --check`
- parsed `.github/workflows/build.yaml` and `.github/workflows/release.yaml` as YAML
- `cmake --build build/release --target CDTWasmTests -- -j "$(nproc)"`

## Notes
- release tags must point to a commit reachable from `origin/master`
- the release workflow expects the matching CI artifact to still be retained; master build artifacts are retained for 30 days
