### PR TITLE
Remove base_per_transaction_net_usage from blockchain_parameters

### DIFF
--- a/libraries/sysiolib/contracts/sysio/privileged.hpp
+++ b/libraries/sysiolib/contracts/sysio/privileged.hpp
@@ -69,11 +69,6 @@ namespace sysio {
       uint32_t max_transaction_net_usage;
 
       /**
-       * The base amount of net usage billed for a transaction to cover incidentals
-       */
-      uint32_t base_per_transaction_net_usage;
-
-      /**
        * The amount of net usage leeway available whilst executing a transaction (still checks against new limits without leeway at the end of the transaction)
        * @brief The amount of net usage leeway available whilst executing a transaction  (still checks against new limits without leeway at the end of the transaction)
        */
@@ -168,7 +163,7 @@ namespace sysio {
 
       SYSLIB_SERIALIZE( blockchain_parameters,
                         (max_block_net_usage)(target_block_net_usage_pct)
-                        (max_transaction_net_usage)(base_per_transaction_net_usage)(net_usage_leeway)
+                        (max_transaction_net_usage)(net_usage_leeway)
                         (context_free_discount_net_usage_num)(context_free_discount_net_usage_den)
 
                         (max_block_cpu_usage)(target_block_cpu_usage_pct)


### PR DESCRIPTION
## Summary
Removes `base_per_transaction_net_usage` (field and SYSLIB_SERIALIZE entry) from `blockchain_parameters`, pairing with the wire-sysio removal of the parameter from `chain_config_v0` (PR link added there). The host's `set_blockchain_parameters_packed` unpacks the packed blob directly into `chain_config_v0`, so this struct must match its fc::raw layout field-for-field.

Note `get_blockchain_parameters`/`set_blockchain_parameters` are compiled into `libsysio` from `sysiolib.cpp`, so contracts must be built against a CDT rebuilt with this header; the system and test contracts committed in the wire-sysio PR were rebuilt that way.