### PR TITLE
Ignore oh-my-claudecode runtime state (.omc/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ __pycache__/
 
 tmp/
 /.env
+
+# oh-my-claudecode runtime state (operational artifacts, never committed)
+.omc/


### PR DESCRIPTION
Adds `.omc/` to `.gitignore` — the oh-my-claudecode orchestration layer writes its runtime state (session state, notepad, logs, plans) into a repo-local `.omc/` directory, which is an operational artifact and never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)