### PR TITLE
packaging: review follow-ups — binutils aliases, prefix-correct installs, dev payload in tgz

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,19 @@ jobs:
     # the platform builds, so this job waits out a full cold build (a cold
     # LLVM-via-vcpkg build is hours, not minutes). Kept under the 6h
     # GitHub-hosted job ceiling.
-    timeout-minutes: 350
+    #
+    # PHASE BUDGET (the resolver is not the only tenant of this timeout):
+    #   resolver  <= 330m  330 polls x 60s sleep, in the "Resolve build runs" step
+    #   verify     ~ 20m   containerized deb+rpm install, find_package, contract
+    #                      compile and static-lib build, pulling ubuntu:24.04 and
+    #                      fedora:latest
+    #   publish    ~  5m   checksums + asset upload
+    #                ----
+    #   total      ~355m   -> 390 leaves headroom rather than letting a
+    #                         slow-but-SUCCESSFUL build time out during
+    #                         verification instead of failing on a real defect.
+    #   (was 350, i.e. under the sum of its own phases.)
+    timeout-minutes: 390
     permissions:
       actions: read
       contents: write

--- a/BUILD.md
+++ b/BUILD.md
@@ -237,7 +237,8 @@ Linux builds; the portable tarball builds on Linux and macOS:
 cd build
 cpack -G DEB                      # wire-cdt_<version>_amd64.deb + wire-cdt-dev_…
 cpack -G RPM                      # wire-cdt-<version>-x86_64.rpm + wire-cdt-dev-…
-cmake --build . --target package-tgz   # wire-cdt-<version>-<arch>.tar.gz
+cpack -G TGZ                      # wire-cdt-<version>-<arch>.tar.gz
+cmake --build . --target package-tgz   # same tarball, convenience alias
 
 sudo apt install ./wire-cdt_*_amd64.deb
 ```
@@ -254,6 +255,15 @@ Debian and Fedora use for a bundled compiler (`/usr/lib/llvm-18/…`):
 
 There is no `/usr/cdt` subtree. The relative layout **inside** `/usr/lib/cdt` is
 byte-for-byte the same one the tarball has under `wire-cdt/`.
+
+`bin/` also carries the **binutils aliases** — `cdt-ar`, `cdt-ranlib`, `cdt-nm`,
+`cdt-objcopy`, `cdt-objdump`, `cdt-readobj`, `cdt-readelf`, `cdt-strip`, each a
+symlink onto its `llvm-*` neighbour. `CDTWasmToolchain.cmake` bakes
+`CMAKE_AR`/`CMAKE_RANLIB` to `<root>/bin/cdt-ar` and `<root>/bin/cdt-ranlib`, so
+they are required for any `add_library(… STATIC …)` built through the packaged
+toolchain. They are deliberately **not** public entry points: nothing invokes
+them by name off `PATH`, only through that absolute path, so they stay private
+to the home like the `llvm-*` binaries they point at.
 
 **Why the private home:** the toolchain bundles its own LLVM. Installing those
 binaries into `/usr/bin` would put `/usr/bin/clang`, `/usr/bin/lld`,
@@ -294,6 +304,15 @@ export PATH=/opt/wire-cdt/bin:$PATH
 cdt-cpp --version
 ```
 
+The tarball carries **both** packaged components, `base` **and** `dev` — so it
+includes the native (host) contract-testing payload: `lib/libnative*.a`,
+`share/cdt/native-contract-src/` and `scripts/gen_native_dispatch.py`. That is
+required rather than optional, because `CDTMacros.cmake` ships in `base` and its
+native-test macros reference the first two by `${CDT_ROOT}` path; a base-only
+tarball would advertise native contract testing while omitting everything it
+needs — and since the tarball is the only macOS artifact, that made native
+contract testing unreachable on macOS entirely.
+
 For CMake projects, point `find_package(cdt)` at the extracted tree:
 
 ```bash
@@ -320,8 +339,11 @@ discovering `CDT_ROOT` **relative to its own location** whenever the baked
 is absolute — so a non-`/opt` extraction must go through `find_package(cdt)`
 rather than the toolchain file.
 
-The deb/rpm copies of both files bake `/usr/lib/cdt` instead; the TGZ variants
-are swapped in at package time by `cmake/cpack-tgz-toolchain-root.cmake`.
+The deb/rpm copies of both files bake `/usr/lib/cdt` instead. **Both packaged
+roots are applied at package time only**, by a CPack pre-build hook per
+generator — `cmake/cpack-system-layout.cmake` for the deb/rpm, and
+`cmake/cpack-tgz-toolchain-root.cmake` for the tarball. A plain
+`cmake --install` never sees either of them; see below.
 
 ### CMake Install
 
@@ -335,6 +357,21 @@ lands directly under `CMAKE_INSTALL_PREFIX` — `<prefix>/bin`, `<prefix>/lib`,
 `<prefix>/include`, `<prefix>/lib/cmake/cdt`, `<prefix>/cdt.imports`. With
 CMake's default prefix that means `/usr/local/bin`, `/usr/local/lib`, … Pass
 `-DCMAKE_INSTALL_PREFIX=<dir>` to choose another root.
+
+`lib/cmake/cdt/` is configured **at install time against the prefix actually in
+effect**, so `cdt-config.cmake` and `CDTWasmToolchain.cmake` name that prefix and
+nothing else — neither packaged root leaks into a plain install:
+
+```bash
+cmake --install build --prefix /tmp/cdt-prefix
+grep CMAKE_CXX_COMPILER /tmp/cdt-prefix/lib/cmake/cdt/CDTWasmToolchain.cmake
+# set(CMAKE_CXX_COMPILER "/tmp/cdt-prefix/bin/cdt-cpp")
+```
+
+This works for `--prefix` too, not just the configure-time
+`-DCMAKE_INSTALL_PREFIX`, because the prefix is only known once `cmake --install`
+runs. `DESTDIR` relocates the output path without changing the baked root, which
+stays the logical prefix the files will be read from.
 
 ### Use from the Build Directory
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,6 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/cdt-config.cmake.in ${CMAKE_BINARY_DIR}
 configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTMacros.cmake.in ${CMAKE_BINARY_DIR}/cmake/CDTMacros.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTWasmToolchain.cmake.in ${CMAKE_BINARY_DIR}/cmake/CDTWasmToolchain.cmake @ONLY)
 
-set(CDT_ROOT_DIR "_PREFIX_")
-configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTMacros.cmake.in ${CMAKE_BINARY_DIR}/cmake/CDTMacrosPackage.cmake @ONLY)
-configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTWasmToolchain.cmake.in ${CMAKE_BINARY_DIR}/cmake/CDTWasmToolchainPackage.cmake @ONLY)
-configure_file(${CMAKE_SOURCE_DIR}/cmake/cdt-config.cmake.in ${CMAKE_BINARY_DIR}/cmake/cdt-config.cmake.package @ONLY)
-
 # SYSTEM-PACKAGE variants of the cmake config/toolchain files, configured for
 # the deb/rpm root: `/usr/lib/cdt`.
 #
@@ -106,7 +101,45 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/cdt-config.cmake.in ${CMAKE_BINARY_DIR}
 configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTMacros.cmake.in ${CMAKE_BINARY_DIR}/packaging/lib/cmake/cdt/CDTMacros.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTWasmToolchain.cmake.in ${CMAKE_BINARY_DIR}/packaging/lib/cmake/cdt/CDTWasmToolchain.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/CDTInternalMacros.cmake ${CMAKE_BINARY_DIR}/packaging/lib/cmake/cdt/CDTInternalMacros.cmake COPYONLY)
-install(DIRECTORY ${CMAKE_BINARY_DIR}/packaging/lib/cmake/cdt/ DESTINATION lib/cmake/cdt COMPONENT base)
+
+# THE lib/cmake/cdt INSTALL RULE -- configured at INSTALL time, against the
+# EFFECTIVE prefix.
+#
+# WHY NOT a plain install(DIRECTORY) of one of the pre-configured variants above:
+# whichever variant were chosen would bake ITS root into every install. That is
+# what shipped before, and it made the documented `cmake --install build
+# --prefix X` path (BUILD.md) produce a toolchain naming /usr/lib/cdt -- so on a
+# machine without the deb, a consumer died immediately with
+# "The CMAKE_CXX_COMPILER: is not a full path to an existing compiler tool",
+# and a prefix-installed cdt-config.cmake preferred a coincidentally-present deb
+# over its own relative discovery.
+#
+# A CONFIGURE-time bake cannot fix this either: `--prefix` is chosen at INSTALL
+# time, long after configure_file has run. So the templates are configured HERE,
+# inside install(CODE), where ${CMAKE_INSTALL_PREFIX} holds the prefix actually
+# in effect -- the configure-time default, or whatever `--prefix` overrode it
+# with. DESTDIR only relocates the OUTPUT path; the baked root stays the logical
+# prefix, which is what the files must name once installed.
+#
+# The two PACKAGED roots are applied strictly at cpack staging, by the pre-build
+# hooks, and never here:
+#   deb / rpm -> /usr/lib/cdt   cmake/cpack-system-layout.cmake
+#   tarball   -> /opt/wire-cdt  cmake/cpack-tgz-toolchain-root.cmake
+# Under cpack, ${CMAKE_INSTALL_PREFIX} is the STAGING directory, so the files
+# this rule writes carry a staging path -- meaningless in a package, and exactly
+# why both hooks overwrite them unconditionally rather than only when they look
+# wrong.
+install(CODE "
+   set(CDT_ROOT_DIR \"\${CMAKE_INSTALL_PREFIX}\")
+   set(VERSION_FULL \"${VERSION_FULL}\")
+   set(SYSROOT_DIR \"${SYSROOT_DIR}\")
+   set(_cdt_cmake_dir \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib/cmake/cdt\")
+   message(STATUS \"wire-cdt: configuring lib/cmake/cdt for prefix \${CMAKE_INSTALL_PREFIX}\")
+   configure_file(\"${CMAKE_SOURCE_DIR}/cmake/cdt-config.cmake.in\"        \"\${_cdt_cmake_dir}/cdt-config.cmake\"        @ONLY)
+   configure_file(\"${CMAKE_SOURCE_DIR}/cmake/CDTMacros.cmake.in\"         \"\${_cdt_cmake_dir}/CDTMacros.cmake\"         @ONLY)
+   configure_file(\"${CMAKE_SOURCE_DIR}/cmake/CDTWasmToolchain.cmake.in\"  \"\${_cdt_cmake_dir}/CDTWasmToolchain.cmake\" @ONLY)
+   configure_file(\"${CMAKE_SOURCE_DIR}/cmake/CDTInternalMacros.cmake\"    \"\${_cdt_cmake_dir}/CDTInternalMacros.cmake\" COPYONLY)
+" COMPONENT base)
 
 # PORTABLE-TARBALL variants. The tarball is rooted at `wire-cdt/` and its
 # DEFAULT install location is /opt -- extracted there the tree lands on exactly

--- a/cmake/InstallCDT.cmake
+++ b/cmake/InstallCDT.cmake
@@ -68,9 +68,33 @@ foreach(tool llvm-ranlib llvm-ar llvm-nm llvm-objcopy llvm-objdump llvm-readobj 
       OPTIONAL)
 endforeach()
 
-# CDT symlinks
+# CDT binutils aliases -- cdt-ar, cdt-ranlib, cdt-nm, ... each a SYMLINK onto its
+# llvm-* counterpart in the same bin/.
+#
+# These MUST be installed, not merely created in the build tree:
+# CDTWasmToolchain.cmake bakes CMAKE_AR=${CDT_ROOT}/bin/cdt-ar and
+# CMAKE_RANLIB=${CDT_ROOT}/bin/cdt-ranlib, so every consumer that builds a STATIC
+# library through the packaged toolchain invokes these paths. Without the install
+# rule the packages shipped a toolchain file naming binaries the payload did not
+# contain, and `add_library(... STATIC ...)` failed at the archive step with
+# "Error running link command: No such file or directory". (The deleted
+# scripts/generate_tarball.sh created these links by hand, so their absence was a
+# payload regression, not a deliberate omission.)
+#
+# NOT public entry points -- deliberately absent from CDT_PUBLIC_ENTRY_POINTS, so
+# they get NO /usr/bin symlink. The cdt- prefix means either choice is
+# collision-free, so the tie is broken on consistency with what the list means:
+# an entry point is a tool a HUMAN or a consuming build invokes BY NAME off PATH
+# (cdt-cpp, cdt-protoc, cdt-pp). These are build-system plumbing addressed only
+# by the ABSOLUTE ${CDT_ROOT}/bin/... path the toolchain file bakes, exactly like
+# the llvm-ar / llvm-ranlib binaries they point at -- which are themselves
+# private to the home. A /usr/bin/cdt-ar would therefore buy nothing and would
+# widen the public surface the layout deliberately keeps minimal.
 foreach(tool ranlib ar nm objcopy objdump readobj readelf strip)
    add_custom_command( TARGET CDTTools POST_BUILD COMMAND cd ${CMAKE_BINARY_DIR}/bin && ln -sf llvm-${tool} cdt-${tool} 2>/dev/null || true )
+   # A RELATIVE symlink onto the sibling llvm-* binary: resolves identically in
+   # the build tree, the cpack staging tree and after install, under any prefix.
+   install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"llvm-${tool}\" \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/cdt-${tool}\")" COMPONENT base)
 endforeach()
 
 # CDT tools

--- a/cmake/cpack-project-config.cmake
+++ b/cmake/cpack-project-config.cmake
@@ -6,13 +6,43 @@
 # Both carry the SAME relative layout; only the home and the extras differ.
 if(CPACK_GENERATOR STREQUAL "TGZ")
    # Portable toolchain tarball: plain `wire-cdt` top-level directory (the
-   # distribution name -- CPACK_WIRE_PACKAGE_NAME, set in cmake/package.cmake).
-   # Monolithic archives take both the artifact name and top dir from
-   # CPACK_PACKAGE_FILE_NAME; the package-tgz target restores the versioned
-   # artifact name afterwards. Base component only.
-   set(CPACK_PACKAGING_INSTALL_PREFIX "/")
-   set(CPACK_PACKAGE_FILE_NAME "${CPACK_WIRE_PACKAGE_NAME}")
-   string(REPLACE ";ALL;/" ";base;/" CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS}")
+   # distribution name -- CPACK_WIRE_PACKAGE_NAME, set in cmake/package.cmake),
+   # in a VERSIONED archive file.
+   #
+   # DECOUPLING THE ARCHIVE NAME FROM THE ROOT DIRECTORY. For a MONOLITHIC
+   # archive CPack takes BOTH from CPACK_PACKAGE_FILE_NAME (the root is the
+   # basename of the staging dir, which is derived from it) and does NOT consult
+   # CPACK_ARCHIVE_FILE_NAME -- that is component-mode only, verified against
+   # this generator. Setting it alone therefore still produced `wire-cdt.tar.gz`.
+   #
+   # So the two are separated at the source instead:
+   #   CPACK_PACKAGE_FILE_NAME          -> the VERSIONED artifact name
+   #   CPACK_INCLUDE_TOPLEVEL_DIRECTORY -> 0, suppressing the automatic root
+   #                                       (which would otherwise be that same
+   #                                       versioned name)
+   #   CPACK_PACKAGING_INSTALL_PREFIX   -> /wire-cdt, so the payload lands under
+   #                                       a `wire-cdt/` root inside the archive
+   #
+   # Net effect: plain `cpack -G TGZ` / `ninja package` now emits
+   # wire-cdt-<VERSION_FULL>-<arch-tag>.tar.gz directly -- matching the CI upload
+   # glob (build/wire-cdt-*.tar.gz) and verify-tgz.sh's wire-cdt-*-<arch>.tar.gz
+   # -- while the root inside stays `wire-cdt/`. Previously only the package-tgz
+   # target's post-hoc rename produced that name, so anyone not running CI's
+   # exact command sequence got an artifact no glob picked up.
+   set(CPACK_PACKAGE_FILE_NAME "${CPACK_WIRE_TGZ_FILE_NAME}")
+   set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
+   set(CPACK_PACKAGING_INSTALL_PREFIX "/${CPACK_WIRE_PACKAGE_NAME}")
+   # base AND dev. CDTMacros.cmake ships in base and its native-test macros
+   # reference ${CDT_ROOT}/scripts/gen_native_dispatch.py and
+   # ${CDT_ROOT}/share/cdt/native-contract-src -- both COMPONENT dev. A
+   # base-only tarball therefore advertised native contract testing while
+   # omitting everything it needs, which also made native testing unreachable
+   # on macOS entirely, the tarball being the only macOS artifact.
+   # Enumerated per component rather than left as ALL so a component added
+   # later joins the tarball deliberately, not silently.
+   string(REPLACE ";ALL;/" ";base;/" _wire_tgz_base "${CPACK_INSTALL_CMAKE_PROJECTS}")
+   string(REPLACE ";ALL;/" ";dev;/"  _wire_tgz_dev  "${CPACK_INSTALL_CMAKE_PROJECTS}")
+   set(CPACK_INSTALL_CMAKE_PROJECTS "${_wire_tgz_base};${_wire_tgz_dev}")
    # The install rules stage the /usr/lib/cdt-baked cmake files (right for the
    # deb and the rpm, wrong for the tarball, whose home is /opt/wire-cdt). This
    # hook runs after staging and before the archive is written, and swaps in the

--- a/cmake/cpack-system-layout.cmake
+++ b/cmake/cpack-system-layout.cmake
@@ -62,6 +62,35 @@ list(REMOVE_DUPLICATES _wire_roots)
 foreach(_wire_root IN LISTS _wire_roots)
    set(_wire_home "${_wire_root}/usr/lib/cdt")
 
+   # ---- /usr/lib/cdt-baked cmake files --------------------------------------
+   # The install rule (CMakeLists.txt) configures lib/cmake/cdt at INSTALL time
+   # against ${CMAKE_INSTALL_PREFIX} -- which under cpack is the STAGING
+   # directory, not /usr/lib/cdt. So the staged files name a build-machine temp
+   # path and must be replaced here with the variants configured for the real
+   # deb/rpm home. This is the DEB/RPM counterpart of the TGZ generator's
+   # /opt/wire-cdt swap in cmake/cpack-tgz-toolchain-root.cmake; the packaged
+   # roots are applied ONLY at staging, so a plain `cmake --install --prefix X`
+   # keeps prefix-correct files.
+   #
+   # Only the two files that bake @CDT_ROOT_DIR@ absolutely need swapping:
+   # cdt-config.cmake (its first branch short-circuits discovery) and
+   # CDTWasmToolchain.cmake (every compiler path is baked, no discovery at all).
+   # CDTMacros.cmake / CDTInternalMacros.cmake bake nothing -- they resolve
+   # through the RUNTIME ${CDT_ROOT} that cdt-config produces.
+   if(IS_DIRECTORY "${_wire_home}/lib/cmake/cdt")
+      foreach(_wire_name cdt-config.cmake CDTWasmToolchain.cmake)
+         set(_wire_variant "${CPACK_WIRE_SYSTEM_CMAKE_DIR}/${_wire_name}")
+         if(NOT EXISTS "${_wire_variant}")
+            message(FATAL_ERROR
+               "system-package cmake file '${_wire_variant}' was not staged -- see "
+               "the packaging/ configure_file block in CMakeLists.txt")
+         endif()
+         configure_file("${_wire_variant}"
+                        "${_wire_home}/lib/cmake/cdt/${_wire_name}" COPYONLY)
+         message(STATUS "wire-cdt: /usr/lib/cdt-baked ${_wire_name} staged into the deb/rpm home")
+      endforeach()
+   endif()
+
    # ---- /usr/bin symlinks, public entry points only -------------------------
    # Only the component that actually carries bin/ (base) grows them.
    if(IS_DIRECTORY "${_wire_home}/bin")

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -156,24 +156,30 @@ set(CPACK_PROJECT_CONFIG_FILE "${CMAKE_SOURCE_DIR}/cmake/cpack-project-config.cm
 set(CPACK_WIRE_PACKAGE_NAME "${WIRE_PACKAGE_NAME}")
 # Same reason: the TGZ-only toolchain-root swap (see cpack-project-config.cmake)
 # needs the hook script plus both portable cmake files staged by the
-# packaging/tgz configure_file block in CMakeLists.txt.
+# packaging/tgz configure_file block in CMakeLists.txt -- and the versioned
+# archive file name, which must differ from the tarball's `wire-cdt/` root.
 set(CPACK_WIRE_TGZ_PRE_BUILD_SCRIPT "${CMAKE_SOURCE_DIR}/cmake/cpack-tgz-toolchain-root.cmake")
+set(CPACK_WIRE_TGZ_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}")
 set(CPACK_WIRE_TGZ_CDT_CONFIG "${CMAKE_BINARY_DIR}/packaging/tgz/lib/cmake/cdt/cdt-config.cmake")
 set(CPACK_WIRE_TGZ_CDT_TOOLCHAIN "${CMAKE_BINARY_DIR}/packaging/tgz/lib/cmake/cdt/CDTWasmToolchain.cmake")
-# ... and the DEB/RPM-only distro-toolchain layout hook needs its script plus the
-# public entry-point list that cmake/InstallCDT.cmake collected from the install
-# rules themselves (one source of truth for "what gets a /usr/bin symlink").
+# ... and the DEB/RPM-only distro-toolchain layout hook needs its script, the
+# directory holding the /usr/lib/cdt-baked cmake variants it stages over the
+# install-time-configured files (see the lib/cmake/cdt install rule in
+# CMakeLists.txt), plus the public entry-point list that cmake/InstallCDT.cmake
+# collected from the install rules themselves (one source of truth for "what
+# gets a /usr/bin symlink").
 set(CPACK_WIRE_SYSTEM_LAYOUT_SCRIPT "${CMAKE_SOURCE_DIR}/cmake/cpack-system-layout.cmake")
+set(CPACK_WIRE_SYSTEM_CMAKE_DIR "${CMAKE_BINARY_DIR}/packaging/lib/cmake/cdt")
 list(REMOVE_DUPLICATES CDT_PUBLIC_ENTRY_POINTS)
 list(SORT CDT_PUBLIC_ENTRY_POINTS)
 set(CPACK_WIRE_PUBLIC_ENTRY_POINTS "${CDT_PUBLIC_ENTRY_POINTS}")
 
-# Portable tarball with the versioned artifact name (see project-config for
-# why plain `cpack -G TGZ` emits wire-cdt.tar.gz).
+# Convenience target for "just build the tarball". `cpack -G TGZ` now emits the
+# versioned name on its own (see the archive-name/root decoupling in
+# cmake/cpack-project-config.cmake), so this no longer renames anything -- it is
+# a plain alias, kept because CI and the docs invoke it by name.
 add_custom_target(package-tgz
    COMMAND "${CMAKE_CPACK_COMMAND}" -G TGZ
-   COMMAND "${CMAKE_COMMAND}" -E rename "${CMAKE_BINARY_DIR}/${WIRE_PACKAGE_NAME}.tar.gz"
-           "${CMAKE_BINARY_DIR}/${CPACK_PACKAGE_FILE_NAME}.tar.gz"
    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
    COMMENT "Packaging ${CPACK_PACKAGE_FILE_NAME}.tar.gz (portable toolchain)"
    VERBATIM)

--- a/tools/packaging/tests/verify-deb.sh
+++ b/tools/packaging/tests/verify-deb.sh
@@ -39,6 +39,22 @@ for f in $cdt_symlinks; do
     echo "$c" | grep -qx "./usr/lib/cdt/bin/$f" || fail "payload missing ./usr/lib/cdt/bin/$f"
     echo "$c" | grep -qx "./usr/bin/$f" || fail "entry-point symlink missing ./usr/bin/$f"
 done
+# BINUTILS ALIASES -- cdt-ar, cdt-ranlib and friends, each a symlink onto its
+# llvm-* counterpart. CDTWasmToolchain.cmake bakes CMAKE_AR=${CDT_ROOT}/bin/cdt-ar
+# and CMAKE_RANLIB=${CDT_ROOT}/bin/cdt-ranlib, so a payload without them ships a
+# toolchain naming binaries it does not contain and every static-library build
+# through it dies at the archive step. They shipped in no artifact at all until
+# cmake/InstallCDT.cmake grew install rules for them; RESOLUTION and actual USE
+# are covered by the container smoke below.
+#
+# Deliberately NOT entry points: unlike the cdt_symlinks above, these are never
+# invoked by name off PATH, only through the absolute path the toolchain file
+# bakes -- so they must be present in the home and ABSENT from /usr/bin.
+cdt_binutils="cdt-ar cdt-ranlib cdt-nm cdt-objcopy cdt-objdump cdt-readobj cdt-readelf cdt-strip"
+for f in $cdt_binutils; do
+    echo "$c" | grep -qx "./usr/lib/cdt/bin/$f" || fail "payload missing ./usr/lib/cdt/bin/$f (CMAKE_AR/CMAKE_RANLIB target)"
+    echo "$c" | grep -qx "./usr/bin/$f" && fail "BANNED: ./usr/bin/$f -- binutils aliases stay private to the home"
+done
 echo "$c" | grep -q "libnative" && fail "base deb leaks native dev libs"
 if [ -n "$dev" ]; then
     dc=$(dpkg-deb -c "$dev" | awk '{print $6}')
@@ -59,6 +75,24 @@ CONTRACT hello : public contract {
    ACTION hi(name user) { print("hi,", user); }
 };
 SRC
+# STATIC-LIBRARY smoke, built THROUGH the packaged toolchain file. This is the
+# end-to-end exercise of CMAKE_AR / CMAKE_RANLIB -- i.e. of the cdt-ar /
+# cdt-ranlib aliases asserted in the payload above. It is a distinct failure
+# mode from the contract compile below: a missing archiver still compiles the
+# object fine and only dies at `Linking CXX static library`, with
+# "Error running link command: No such file or directory". The entry-point and
+# payload checks alone missed exactly this, which is why the functional build is
+# here and not just a presence assertion.
+mkdir -p "$smoke/lib"
+cat > "$smoke/lib/lib.cpp" <<'LIBSRC'
+#include <sysio/sysio.hpp>
+int add_two(int a, int b) { return a + b; }
+LIBSRC
+cat > "$smoke/lib/CMakeLists.txt" <<'LIBCM'
+cmake_minimum_required(VERSION 3.19)
+project(cdt_static_lib_smoke CXX)
+add_library(mylib STATIC lib.cpp)
+LIBCM
 # find_package(cdt) with ZERO setup -- no CMAKE_PREFIX_PATH, no cdt_DIR. The
 # discoverable copy at /usr/lib/cmake/cdt is what makes that work (/usr/lib/cdt
 # is NOT on CMake's default search path); it bakes CDT_ROOT=/usr/lib/cdt, so
@@ -106,6 +140,19 @@ docker run --rm -v "$pkgdir":/pkg -v "$smoke":/smoke ubuntu:24.04 bash -ec "
     # The packaged toolchain must be reachable through plain find_package(cdt)
     # with no prefix hints at all.
     cmake -S /smoke/fp -B /tmp/fp > /tmp/fp.log 2>&1 || { echo 'SMOKE FAIL: find_package(cdt)'; tail -20 /tmp/fp.log; exit 1; }
+    # The binutils aliases must RESOLVE (test -x follows the link to llvm-*) ...
+    for tool in $cdt_binutils; do
+        test -x /usr/lib/cdt/bin/\$tool || { echo \"SMOKE FAIL: /usr/lib/cdt/bin/\$tool missing or dangling\"; exit 1; }
+        test -e /usr/bin/\$tool && { echo \"SMOKE FAIL: /usr/bin/\$tool -- binutils aliases must stay private\"; exit 1; }
+    done
+    # ... and must actually WORK as CMAKE_AR / CMAKE_RANLIB. Static archiving is
+    # the step the packaged toolchain could not perform before the aliases were
+    # installed.
+    cmake -S /smoke/lib -B /tmp/lib \\
+        -DCMAKE_TOOLCHAIN_FILE=/usr/lib/cdt/lib/cmake/cdt/CDTWasmToolchain.cmake \\
+        > /tmp/lib-cfg.log 2>&1 || { echo 'SMOKE FAIL: static-lib configure'; tail -20 /tmp/lib-cfg.log; exit 1; }
+    cmake --build /tmp/lib > /tmp/lib-bld.log 2>&1 || { echo 'SMOKE FAIL: static-lib build (CMAKE_AR/CMAKE_RANLIB)'; tail -20 /tmp/lib-bld.log; exit 1; }
+    test -s /tmp/lib/libmylib.a || { echo 'SMOKE FAIL: libmylib.a missing/empty'; exit 1; }
     # Functional smoke THROUGH THE /usr/bin SYMLINK. /usr/lib/cdt/bin is
     # deliberately NOT on PATH, so a bare \`cdt-cpp\` can only be the symlink.
     # This is the load-bearing check for whereami's realpath(/proc/self/exe)
@@ -125,4 +172,4 @@ docker run --rm -v "$pkgdir":/pkg -v "$smoke":/smoke ubuntu:24.04 bash -ec "
     test -s hello.wasm || { echo 'SMOKE FAIL: hello.wasm missing/empty'; exit 1; }
     test -s hello.abi || { echo 'SMOKE FAIL: hello.abi missing/empty'; exit 1; }
 " || fail "container install / contract-compile smoke"
-echo "S2 PASS: $d ${dev:+(+ $dev)} (contract smoke: wasm+abi produced)"
+echo "S2 PASS: $d ${dev:+(+ $dev)} (smoke: wasm+abi + static lib produced)"

--- a/tools/packaging/tests/verify-rpm.sh
+++ b/tools/packaging/tests/verify-rpm.sh
@@ -39,6 +39,22 @@ for f in $cdt_symlinks; do
     echo "$l" | grep -qx "/usr/lib/cdt/bin/$f" || fail "payload missing /usr/lib/cdt/bin/$f"
     echo "$l" | grep -qx "/usr/bin/$f" || fail "entry-point symlink missing /usr/bin/$f"
 done
+# BINUTILS ALIASES -- cdt-ar, cdt-ranlib and friends, each a symlink onto its
+# llvm-* counterpart. CDTWasmToolchain.cmake bakes CMAKE_AR=${CDT_ROOT}/bin/cdt-ar
+# and CMAKE_RANLIB=${CDT_ROOT}/bin/cdt-ranlib, so a payload without them ships a
+# toolchain naming binaries it does not contain and every static-library build
+# through it dies at the archive step. They shipped in no artifact at all until
+# cmake/InstallCDT.cmake grew install rules for them; RESOLUTION and actual USE
+# are covered by the container smoke below.
+#
+# Deliberately NOT entry points: unlike the cdt_symlinks above, these are never
+# invoked by name off PATH, only through the absolute path the toolchain file
+# bakes -- so they must be present in the home and ABSENT from /usr/bin.
+cdt_binutils="cdt-ar cdt-ranlib cdt-nm cdt-objcopy cdt-objdump cdt-readobj cdt-readelf cdt-strip"
+for f in $cdt_binutils; do
+    echo "$l" | grep -qx "/usr/lib/cdt/bin/$f" || fail "payload missing /usr/lib/cdt/bin/$f (CMAKE_AR/CMAKE_RANLIB target)"
+    echo "$l" | grep -qx "/usr/bin/$f" && fail "BANNED: /usr/bin/$f -- binutils aliases stay private to the home"
+done
 echo "$l" | grep -q "libnative" && fail "base rpm leaks native dev libs"
 v=$(rpm -qp --qf '%{VERSION}' "$r" 2>/dev/null)
 case "$v" in *-*) fail "version tag contains hyphen: $v" ;; esac
@@ -57,6 +73,24 @@ CONTRACT hello : public contract {
    ACTION hi(name user) { print("hi,", user); }
 };
 SRC
+# STATIC-LIBRARY smoke, built THROUGH the packaged toolchain file. This is the
+# end-to-end exercise of CMAKE_AR / CMAKE_RANLIB -- i.e. of the cdt-ar /
+# cdt-ranlib aliases asserted in the payload above. It is a distinct failure
+# mode from the contract compile below: a missing archiver still compiles the
+# object fine and only dies at `Linking CXX static library`, with
+# "Error running link command: No such file or directory". The entry-point and
+# payload checks alone missed exactly this, which is why the functional build is
+# here and not just a presence assertion.
+mkdir -p "$smoke/lib"
+cat > "$smoke/lib/lib.cpp" <<'LIBSRC'
+#include <sysio/sysio.hpp>
+int add_two(int a, int b) { return a + b; }
+LIBSRC
+cat > "$smoke/lib/CMakeLists.txt" <<'LIBCM'
+cmake_minimum_required(VERSION 3.19)
+project(cdt_static_lib_smoke CXX)
+add_library(mylib STATIC lib.cpp)
+LIBCM
 # find_package(cdt) with ZERO setup -- no CMAKE_PREFIX_PATH, no cdt_DIR. The
 # discoverable copy at /usr/lib/cmake/cdt is what makes that work (/usr/lib/cdt
 # is NOT on CMake's default search path); it bakes CDT_ROOT=/usr/lib/cdt, so
@@ -102,6 +136,19 @@ docker run --rm -v "$pkgdir":/pkg -v "$smoke":/smoke fedora:latest bash -ec "
     # The packaged toolchain must be reachable through plain find_package(cdt)
     # with no prefix hints at all.
     cmake -S /smoke/fp -B /tmp/fp > /tmp/fp.log 2>&1 || { echo 'SMOKE FAIL: find_package(cdt)'; tail -20 /tmp/fp.log; exit 1; }
+    # The binutils aliases must RESOLVE (test -x follows the link to llvm-*) ...
+    for tool in $cdt_binutils; do
+        test -x /usr/lib/cdt/bin/\$tool || { echo \"SMOKE FAIL: /usr/lib/cdt/bin/\$tool missing or dangling\"; exit 1; }
+        test -e /usr/bin/\$tool && { echo \"SMOKE FAIL: /usr/bin/\$tool -- binutils aliases must stay private\"; exit 1; }
+    done
+    # ... and must actually WORK as CMAKE_AR / CMAKE_RANLIB. Static archiving is
+    # the step the packaged toolchain could not perform before the aliases were
+    # installed.
+    cmake -S /smoke/lib -B /tmp/lib \\
+        -DCMAKE_TOOLCHAIN_FILE=/usr/lib/cdt/lib/cmake/cdt/CDTWasmToolchain.cmake \\
+        > /tmp/lib-cfg.log 2>&1 || { echo 'SMOKE FAIL: static-lib configure'; tail -20 /tmp/lib-cfg.log; exit 1; }
+    cmake --build /tmp/lib > /tmp/lib-bld.log 2>&1 || { echo 'SMOKE FAIL: static-lib build (CMAKE_AR/CMAKE_RANLIB)'; tail -20 /tmp/lib-bld.log; exit 1; }
+    test -s /tmp/lib/libmylib.a || { echo 'SMOKE FAIL: libmylib.a missing/empty'; exit 1; }
     # Functional smoke THROUGH THE /usr/bin SYMLINK. /usr/lib/cdt/bin is
     # deliberately NOT on PATH, so a bare \`cdt-cpp\` can only be the symlink.
     # This is the load-bearing check for whereami's realpath(/proc/self/exe)
@@ -121,4 +168,4 @@ docker run --rm -v "$pkgdir":/pkg -v "$smoke":/smoke fedora:latest bash -ec "
     test -s hello.wasm || { echo 'SMOKE FAIL: hello.wasm missing/empty'; exit 1; }
     test -s hello.abi || { echo 'SMOKE FAIL: hello.abi missing/empty'; exit 1; }
 " || fail "container install / contract-compile smoke"
-echo "S3 PASS: $r ${dev:+(+ $dev)} (contract smoke: wasm+abi produced)"
+echo "S3 PASS: $r ${dev:+(+ $dev)} (smoke: wasm+abi + static lib produced)"

--- a/tools/packaging/tests/verify-tgz.sh
+++ b/tools/packaging/tests/verify-tgz.sh
@@ -34,8 +34,26 @@ if [ "$no_service" = "1" ]; then
     svc=$(echo "$list" | grep -E '(^|/)(lib/systemd|lib/tmpfiles\.d|etc/logrotate\.d)/' || true)
     [ -z "$svc" ] || fail "tarball carries service payload: $svc"
 fi
-n=$(echo "$list" | grep -c "libnative" || true)
-[ "$n" = "0" ] || fail "portable tarball leaks native dev libs"
+# BINUTILS ALIASES -- cdt-ar, cdt-ranlib and friends, symlinks onto their llvm-*
+# counterparts. CDTWasmToolchain.cmake bakes CMAKE_AR=${CDT_ROOT}/bin/cdt-ar and
+# CMAKE_RANLIB=${CDT_ROOT}/bin/cdt-ranlib, so without them the tarball ships a
+# toolchain naming binaries it does not contain and every static-library build
+# through it fails at the archive step. RESOLUTION is checked against the
+# extracted copy below.
+cdt_binutils="bin/cdt-ar bin/cdt-ranlib bin/cdt-nm bin/cdt-objcopy bin/cdt-objdump bin/cdt-readobj bin/cdt-readelf bin/cdt-strip"
+for f in $cdt_binutils; do
+    echo "$list" | grep -qx "wire-cdt/$f" || fail "missing wire-cdt/$f (CMAKE_AR/CMAKE_RANLIB target)"
+done
+# THE TARBALL CARRIES base AND dev. CDTMacros.cmake ships in base and its
+# native-test macros reference ${CDT_ROOT}/scripts/gen_native_dispatch.py and
+# ${CDT_ROOT}/share/cdt/native-contract-src -- both COMPONENT dev. A base-only
+# tarball advertised native contract testing while omitting everything it needs,
+# and since the tarball is the ONLY macOS artifact that made native contract
+# testing unreachable on macOS entirely. So these are now REQUIRED payload, the
+# exact inverse of the old "portable tarball leaks native dev libs" assertion.
+echo "$list" | grep -q "libnative" || fail "tarball missing the native (dev) testing libs"
+echo "$list" | grep -q "share/cdt/native-contract-src/" || fail "tarball missing share/cdt/native-contract-src/"
+echo "$list" | grep -qx "wire-cdt/scripts/gen_native_dispatch.py" || fail "tarball missing scripts/gen_native_dispatch.py"
 
 # Extract and resolve: `[ -e ]` follows the link, so a symlink whose target was
 # never packaged (or was packaged under a different name) fails here.
@@ -43,6 +61,10 @@ x=$(mktemp -d)
 trap 'rm -rf "$x"' EXIT
 tar xzf "$t" -C "$x"
 for f in $cdt_symlinks; do
+    [ -L "$x/wire-cdt/$f" ] || fail "wire-cdt/$f is not a symlink"
+    [ -e "$x/wire-cdt/$f" ] || fail "dangling symlink wire-cdt/$f -> $(readlink "$x/wire-cdt/$f")"
+done
+for f in $cdt_binutils; do
     [ -L "$x/wire-cdt/$f" ] || fail "wire-cdt/$f is not a symlink"
     [ -e "$x/wire-cdt/$f" ] || fail "dangling symlink wire-cdt/$f -> $(readlink "$x/wire-cdt/$f")"
 done
@@ -62,7 +84,28 @@ grep -q '"/opt/wire-cdt/bin/cdt-cpp"' "$tc" \
 # No packaged artifact may reference /usr/cdt, and the tarball must not ship the
 # deb/rpm (/usr-baked) config either.
 grep -q '/usr/cdt' "$cfg" "$tc" && fail "tarball cmake files reference /usr/cdt"
-grep -q 'IS_DIRECTORY "/usr"' "$cfg" \
+# THE /usr-BAKED-CONFIG GUARD. The pattern deliberately leaves the string
+# UNTERMINATED after /usr so it matches every system-package root, not just a
+# bare /usr: the deb/rpm variant bakes IS_DIRECTORY "/usr/lib/cdt", so the old
+# fully-quoted 'IS_DIRECTORY "/usr"' could never match and this gate was dead --
+# it "passed" on the tarball for the wrong reason and would have passed on the
+# /usr-baked file it exists to catch.
+#
+# Kept as a FUNCTION so the self-test below exercises the exact expression the
+# gate uses; a self-test against a re-typed copy of the pattern would prove
+# nothing about the gate itself.
+usr_baked_config() { grep -q 'IS_DIRECTORY "/usr' "$1"; }
+# SELF-TEST -- the guard must FIRE on a system-variant file and stay SILENT on a
+# portable one. Without this, a future edit could re-break the pattern and the
+# gate would once again pass by never matching anything.
+st=$(mktemp -d); trap 'rm -rf "$x" "$st"' EXIT
+printf 'if(IS_DIRECTORY "/usr/lib/cdt")\n' > "$st/system.cmake"
+printf 'if(IS_DIRECTORY "/opt/wire-cdt")\n' > "$st/portable.cmake"
+usr_baked_config "$st/system.cmake" \
+    || fail "self-test: the /usr-baked guard does NOT fire on a /usr/lib/cdt-baked config (the gate is dead)"
+usr_baked_config "$st/portable.cmake" \
+    && fail "self-test: the /usr-baked guard fires on a portable /opt/wire-cdt config (false positive)"
+usr_baked_config "$cfg" \
     && fail "tarball ships the /usr-baked cdt-config.cmake"
 # The relative-discovery fallback must stay intact so an extraction ANYWHERE
 # other than /opt still resolves CDT_ROOT from the config file's own location.


### PR DESCRIPTION
Addresses every finding from the [PR #100 packaging review](https://github.com/Wire-Network/wire-cdt/pull/100#pullrequestreview-4797574824), each fix verified against real cpack artifacts (probe build, 39 binaries):

1. **Binutils aliases ship** — install rules for the 8 cdt-* alias symlinks; static-archive builds through the packaged toolchain now work (reproduced the reported failure, proved the fix). Kept out of /usr/bin by design (toolchain-internal); verifiers assert both sides + a functional STATIC-lib smoke in the container tests.
2. **Prefix installs are prefix-correct** — install-time configure_file; packaged-root bakes moved fully into cpack staging hooks. `cmake --install build --prefix /tmp/x` → zero /usr/lib/cdt references.
3. **verify-tgz /usr-guard revived** with a self-test that proves the gate fires.
4. **TGZ = base+dev** (native-testing payload in the portable tarball, the only macOS artifact) with required-payload assertions.
5. **`cpack -G TGZ` emits the versioned name** directly (CPACK_ARCHIVE_FILE_NAME is component-mode-only and was silently ignored — root cause of the unversioned tarball).
6. Dead `_PREFIX_` variants deleted; release job timeout raised to 390m with a per-phase budget comment.

Companion PR: wire-sysio resolver hardening.